### PR TITLE
Minimal example works on windows with msvc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.23)
 project(libisyntax)
 
 set(CMAKE_C_STANDARD 17)

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -2114,7 +2114,7 @@ bool isyntax_hulsken_decompress(u8* compressed, size_t compressed_size, i32 bloc
 	// Check that the serialized length is sane
 	if (serialized_length > 2 * coeff_buffer_size) {
 //		dump_block(compressed, compressed_size);
-		console_print_error("Error: isyntax_hulsken_decompress(): invalid codeblock, serialized_length too large (%d)\n", serialized_length);
+		console_print_error("Error: isyntax_hulsken_decompress(): invalid codeblock, serialized_length too large (%lld)\n", serialized_length);
 		ASSERT(!"serialized_length too large");
 		memset(out_buffer, 0, coeff_buffer_size);
 		release_temp_memory(&temp_memory);
@@ -2364,7 +2364,7 @@ bool isyntax_hulsken_decompress(u8* compressed, size_t compressed_size, i32 bloc
 
 	if (serialized_length != decompressed_length) {
 //		dump_block(compressed, compressed_size);
-		console_print("iSyntax: decompressed size mismatch (size=%d): expected %d observed %d\n",
+		console_print("iSyntax: decompressed size mismatch (size=%d): expected %lld observed %d\n",
 				 compressed_size, serialized_length, decompressed_length);
 		ASSERT(!"size mismatch");
 	}
@@ -2580,7 +2580,7 @@ static void isyntax_dump_block_header(isyntax_image_t* wsi_image, const char* fi
 
 		for (i32 i = 0; i < wsi_image->codeblock_count; i += 1/*21*3*/) {
 			isyntax_codeblock_t* codeblock = wsi_image->codeblocks + i;
-			fprintf(test_block_header_fp, "%d,%d,%d,%d,%d,%d,%d,%d\n",
+			fprintf(test_block_header_fp, "%d,%d,%d,%d,%d,%lld,%lld,%d\n",
 //			        codeblock->x_adjusted,
 //			        codeblock->y_adjusted,
 			        codeblock->x_coordinate - wsi_image->offset_x,

--- a/src/isyntax_example.c
+++ b/src/isyntax_example.c
@@ -2,17 +2,36 @@
 
 #include "isyntax.h"
 
+#define LOG_VAR(fmt, var) printf("%s: %s=" fmt "\n", __FUNCTION__, #var, var)
+
 int main(int argc, char** argv) {
 
 	if (argc <= 1) {
+        printf("Usage: %s <isyntax_file> - show levels & tiles.\n"
+               "       %s <isyntax_file> <scale> <tile_x> <tile_y> <output.png> - write a tile to output.png",
+               argv[0], argv[0]);
 		return 0;
 	}
 
 	char* filename = argv[1];
 
-	isyntax_t isyntax = {};
+	isyntax_t isyntax = {0};
 	if (isyntax_open(&isyntax, filename)) {
 		printf("Successfully opened %s\n", filename);
+
+        int wsi_image_idx = isyntax.wsi_image_index;
+        LOG_VAR("%d", wsi_image_idx);
+        isyntax_image_t* wsi_image = &isyntax.images[wsi_image_idx];
+        isyntax_level_t* levels = wsi_image->levels;
+
+        for (int i = 0; i < wsi_image->level_count; ++i) {
+            LOG_VAR("%d", i);
+            LOG_VAR("%d", levels[i].scale);
+            LOG_VAR("%d", levels[i].width_in_tiles);
+            LOG_VAR("%d", levels[i].height_in_tiles);
+        }
+
+        isyntax_destroy(&isyntax);
 	}
 
 	return 0;

--- a/src/platform/win32_utils.c
+++ b/src/platform/win32_utils.c
@@ -124,7 +124,7 @@ size_t win32_overlapped_read(thread_memory_t* thread_memory, HANDLE file_handle,
 	// To submit an async I/O request on Win32, we need to fill in an OVERLAPPED structure with the
 	// offset in the file where we want to do the read operation
 	LARGE_INTEGER offset_ = {.QuadPart = (i64)aligned_offset};
-	OVERLAPPED overlapped = {};
+	OVERLAPPED overlapped = {0};
 	overlapped.Offset = offset_.LowPart;
 	overlapped.OffsetHigh = (DWORD)offset_.HighPart;
 	overlapped.hEvent = thread_memory->async_io_events[0];
@@ -229,7 +229,7 @@ void file_stream_write(void* source, size_t bytes_to_write, file_stream_t file_s
 }
 
 i64 file_stream_get_filesize(file_stream_t file_stream) {
-	LARGE_INTEGER filesize = {};
+	LARGE_INTEGER filesize = {0};
 	if (!GetFileSizeEx(file_stream, &filesize)) {
 		win32_diagnostic("GetFileSizeEx");
 	}
@@ -237,8 +237,8 @@ i64 file_stream_get_filesize(file_stream_t file_stream) {
 }
 
 i64 file_stream_get_pos(file_stream_t file_stream) {
-	LARGE_INTEGER file_position = {};
-	LARGE_INTEGER distance_to_move = {};
+	LARGE_INTEGER file_position = {0};
+	LARGE_INTEGER distance_to_move = {0};
 	if (!SetFilePointerEx(file_stream, distance_to_move, &file_position, FILE_CURRENT)) {
 		win32_diagnostic("SetFilePointerEx");
 	}
@@ -246,7 +246,7 @@ i64 file_stream_get_pos(file_stream_t file_stream) {
 }
 
 bool file_stream_set_pos(file_stream_t file_stream, i64 offset) {
-	LARGE_INTEGER new_file_pointer = {};
+	LARGE_INTEGER new_file_pointer = {0};
 	new_file_pointer.QuadPart = offset;
 	if (!SetFilePointerEx(file_stream, new_file_pointer, NULL, FILE_BEGIN)) {
 		win32_diagnostic("SetFilePointerEx");

--- a/src/platform/work_queue.c
+++ b/src/platform/work_queue.c
@@ -37,7 +37,7 @@
 #endif
 
 work_queue_t create_work_queue(const char* semaphore_name, i32 entry_count) {
-	work_queue_t queue = {};
+	work_queue_t queue = {0};
 
 	i32 semaphore_initial_count = 0;
 #if WINDOWS


### PR DESCRIPTION
- example code to read isyntax metadata.
- Cmake downgrade to v3.23 - that's the latest supported by clion.
- minor bugfixes of var={}, which is not standard and not allowed by msvc.
- minor correction of printf formats for long ints.