### PR TITLE
Implementation of isyntax_reader.c and proper API/ABI.

### DIFF
--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -1779,8 +1779,10 @@ u32* isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 
 	isyntax_level_t* level = wsi->levels + scale;
 	ASSERT(tile_x >= 0 && tile_x < level->width_in_tiles);
 	ASSERT(tile_y >= 0 && tile_y < level->height_in_tiles);
+	isyntax_tile_t* tile = level->tiles + tile_y * level->width_in_tiles + tile_x;
 	i32 block_width = isyntax->block_width;
 	i32 block_height = isyntax->block_height;
+	size_t block_size = block_width * block_height * sizeof(icoeff_t);
 	i32 first_valid_pixel = ISYNTAX_IDWT_FIRST_VALID_PIXEL;
 	i32 idwt_width = 2 * (block_width + ISYNTAX_IDWT_PAD_L + ISYNTAX_IDWT_PAD_R);
 	i32 idwt_height = 2 * (block_height + ISYNTAX_IDWT_PAD_L + ISYNTAX_IDWT_PAD_R);
@@ -3131,11 +3133,11 @@ void isyntax_destroy(isyntax_t* isyntax) {
 			}
 		}
 	}
-	if (isyntax->ll_coeff_block_allocator.is_valid) {
-		block_allocator_destroy(&isyntax->ll_coeff_block_allocator);
+	if (isyntax->ll_coeff_block_allocator->is_valid) {
+		block_allocator_destroy(isyntax->ll_coeff_block_allocator);
 	}
-	if (isyntax->h_coeff_block_allocator.is_valid) {
-		block_allocator_destroy(&isyntax->h_coeff_block_allocator);
+	if (isyntax->h_coeff_block_allocator->is_valid) {
+		block_allocator_destroy(isyntax->h_coeff_block_allocator);
 	}
 	if (isyntax->black_dummy_coeff) {
 		free(isyntax->black_dummy_coeff);

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -3133,12 +3133,14 @@ void isyntax_destroy(isyntax_t* isyntax) {
 			}
 		}
 	}
-	if (isyntax->ll_coeff_block_allocator->is_valid) {
-		block_allocator_destroy(isyntax->ll_coeff_block_allocator);
-	}
-	if (isyntax->h_coeff_block_allocator->is_valid) {
-		block_allocator_destroy(isyntax->h_coeff_block_allocator);
-	}
+    if (isyntax->is_block_allocator_owned) {
+        if (isyntax->ll_coeff_block_allocator->is_valid) {
+            block_allocator_destroy(isyntax->ll_coeff_block_allocator);
+        }
+        if (isyntax->h_coeff_block_allocator->is_valid) {
+            block_allocator_destroy(isyntax->h_coeff_block_allocator);
+        }
+    }
 	if (isyntax->black_dummy_coeff) {
 		free(isyntax->black_dummy_coeff);
 		isyntax->black_dummy_coeff = NULL;

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -1774,14 +1774,13 @@ u32 isyntax_idwt_tile_for_color_channel(isyntax_t* isyntax, isyntax_image_t* wsi
 	return invalid_edges;
 }
 
-u32* isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y) {
+u32* isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y, block_allocator_t* ll_coeff_block_allocator, bool decode_rgb) {
+	// printf("@@@ isyntax_load_tile scale=%d tile_x=%d tile_y=%d\n", scale, tile_x, tile_y);
 	isyntax_level_t* level = wsi->levels + scale;
 	ASSERT(tile_x >= 0 && tile_x < level->width_in_tiles);
 	ASSERT(tile_y >= 0 && tile_y < level->height_in_tiles);
-	isyntax_tile_t* tile = level->tiles + tile_y * level->width_in_tiles + tile_x;
 	i32 block_width = isyntax->block_width;
 	i32 block_height = isyntax->block_height;
-	size_t block_size = block_width * block_height * sizeof(icoeff_t);
 	i32 first_valid_pixel = ISYNTAX_IDWT_FIRST_VALID_PIXEL;
 	i32 idwt_width = 2 * (block_width + ISYNTAX_IDWT_PAD_L + ISYNTAX_IDWT_PAD_R);
 	i32 idwt_height = 2 * (block_height + ISYNTAX_IDWT_PAD_L + ISYNTAX_IDWT_PAD_R);
@@ -1817,95 +1816,103 @@ u32* isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 
 			} break;
 		}
 
-		// Distribute result to child tiles
-		if (scale > 0) {
-			isyntax_level_t* next_level = wsi->levels + (scale - 1);
-			isyntax_tile_t* child_top_left = next_level->tiles + (tile_y*2) * next_level->width_in_tiles + (tile_x*2);
-			isyntax_tile_t* child_top_right = child_top_left + 1;
-			isyntax_tile_t* child_bottom_left = child_top_left + next_level->width_in_tiles;
-			isyntax_tile_t* child_bottom_right = child_bottom_left + 1;
+		if (scale == 0) {
+			// No children to take care of at level 0.
+			continue;
+		}
 
-			ASSERT(child_top_left->color_channels[color].coeff_ll == NULL);
-			ASSERT(child_top_right->color_channels[color].coeff_ll == NULL);
-			ASSERT(child_bottom_left->color_channels[color].coeff_ll == NULL);
-			ASSERT(child_bottom_right->color_channels[color].coeff_ll == NULL);
+		// Distribute result to child tiles if it was not distributed already.
+		isyntax_level_t* next_level = wsi->levels + (scale - 1);
+		isyntax_tile_t* child_top_left = next_level->tiles + (tile_y*2) * next_level->width_in_tiles + (tile_x*2);
+		isyntax_tile_t* child_top_right = child_top_left + 1;
+		isyntax_tile_t* child_bottom_left = child_top_left + next_level->width_in_tiles;
+		isyntax_tile_t* child_bottom_right = child_bottom_left + 1;
 
-			// NOTE: malloc() and free() can become a bottleneck, they don't scale well especially across many threads.
-			// We use a custom block allocator to address this.
-			i64 start_malloc = get_clock();
-			child_top_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(&isyntax->ll_coeff_block_allocator);
-			child_top_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(&isyntax->ll_coeff_block_allocator);
-			child_bottom_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(&isyntax->ll_coeff_block_allocator);
-			child_bottom_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(&isyntax->ll_coeff_block_allocator);
-			elapsed_malloc += get_seconds_elapsed(start_malloc, get_clock());
+		// TODO(avirodov): instead of releasing here, skip copy if still allocated.
+		if (child_top_left->color_channels[color].coeff_ll) {
+			block_free(ll_coeff_block_allocator, child_top_left->color_channels[color].coeff_ll);
+		}
+		if (child_top_right->color_channels[color].coeff_ll) {
+			block_free(ll_coeff_block_allocator, child_top_right->color_channels[color].coeff_ll);
+		}
+		if (child_bottom_left->color_channels[color].coeff_ll) {
+			block_free(ll_coeff_block_allocator, child_bottom_left->color_channels[color].coeff_ll);
+		}
+		if (child_bottom_right->color_channels[color].coeff_ll) {
+			block_free(ll_coeff_block_allocator, child_bottom_right->color_channels[color].coeff_ll);
+		}
 
-			i32 dest_stride = block_width;
-			// Blit top left child LL block
-			{
-				icoeff_t* dest = child_top_left->color_channels[color].coeff_ll;
-				icoeff_t* source = idwt + (first_valid_pixel * idwt_stride) + first_valid_pixel;
-				for (i32 y = 0; y < block_height; ++y) {
-					memcpy(dest, source, row_copy_size);
-					dest += dest_stride;
-					source += idwt_stride;
-				}
+		// NOTE: malloc() and free() can become a bottleneck, they don't scale well especially across many threads.
+		// We use a custom block allocator to address this.
+		i64 start_malloc = get_clock();
+		child_top_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
+		child_top_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
+		child_bottom_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
+		child_bottom_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
+		elapsed_malloc += get_seconds_elapsed(start_malloc, get_clock());
+		i32 dest_stride = block_width;
+		// Blit top left child LL block
+		{
+			icoeff_t* dest = child_top_left->color_channels[color].coeff_ll;
+			icoeff_t* source = idwt + (first_valid_pixel * idwt_stride) + first_valid_pixel;
+			for (i32 y = 0; y < block_height; ++y) {
+				memcpy(dest, source, row_copy_size);
+				dest += dest_stride;
+				source += idwt_stride;
 			}
-			// Blit top right child LL block
-			{
-				icoeff_t* dest = child_top_right->color_channels[color].coeff_ll;
-				icoeff_t* source = idwt + (first_valid_pixel * idwt_stride) + first_valid_pixel + block_width;
-				for (i32 y = 0; y < block_height; ++y) {
-					memcpy(dest, source, row_copy_size);
-					dest += dest_stride;
-					source += idwt_stride;
-				}
+		}
+		// Blit top right child LL block
+		{
+			icoeff_t* dest = child_top_right->color_channels[color].coeff_ll;
+			icoeff_t* source = idwt + (first_valid_pixel * idwt_stride) + first_valid_pixel + block_width;
+			for (i32 y = 0; y < block_height; ++y) {
+				memcpy(dest, source, row_copy_size);
+				dest += dest_stride;
+				source += idwt_stride;
 			}
-			// Blit bottom left child LL block
-			{
-				icoeff_t* dest = child_bottom_left->color_channels[color].coeff_ll;
-				icoeff_t* source = idwt + ((first_valid_pixel + block_height) * idwt_stride) + first_valid_pixel;
-				for (i32 y = 0; y < block_height; ++y) {
-					memcpy(dest, source, row_copy_size);
-					dest += dest_stride;
-					source += idwt_stride;
-				}
+		}
+		// Blit bottom left child LL block
+		{
+			icoeff_t* dest = child_bottom_left->color_channels[color].coeff_ll;
+			icoeff_t* source = idwt + ((first_valid_pixel + block_height) * idwt_stride) + first_valid_pixel;
+			for (i32 y = 0; y < block_height; ++y) {
+				memcpy(dest, source, row_copy_size);
+				dest += dest_stride;
+				source += idwt_stride;
 			}
-			// Blit bottom right child LL block
-			{
-				icoeff_t* dest = child_bottom_right->color_channels[color].coeff_ll;
-				icoeff_t* source = idwt + ((first_valid_pixel + block_height) * idwt_stride) + first_valid_pixel + block_width;
-				for (i32 y = 0; y < block_height; ++y) {
-					memcpy(dest, source, row_copy_size);
-					dest += dest_stride;
-					source += idwt_stride;
-				}
+		}
+		// Blit bottom right child LL block
+		{
+			icoeff_t* dest = child_bottom_right->color_channels[color].coeff_ll;
+			icoeff_t* source = idwt + ((first_valid_pixel + block_height) * idwt_stride) + first_valid_pixel + block_width;
+			for (i32 y = 0; y < block_height; ++y) {
+				memcpy(dest, source, row_copy_size);
+				dest += dest_stride;
+				source += idwt_stride;
 			}
+		}
 
-			// After the last color channel, we can report that the children now have their LL blocks available.
-			if (color == 2) {
-				child_top_left->has_ll = true;
-				child_top_right->has_ll = true;
-				child_bottom_left->has_ll = true;
-				child_bottom_right->has_ll = true;
+		// After the last color channel, we can report that the children now have their LL blocks available.
+		if (color == 2) {
+			child_top_left->has_ll = true;
+			child_top_right->has_ll = true;
+			child_bottom_left->has_ll = true;
+			child_bottom_right->has_ll = true;
 
-				// Even if the parent tile has invalid edges around the outside, its child LL blocks will still have valid edges on the inside.
-				child_top_left->ll_invalid_edges = invalid_edges & ~(ISYNTAX_ADJ_TILE_CENTER_RIGHT | ISYNTAX_ADJ_TILE_BOTTOM_RIGHT | ISYNTAX_ADJ_TILE_BOTTOM_CENTER);
-				child_top_right->ll_invalid_edges = invalid_edges & ~(ISYNTAX_ADJ_TILE_CENTER_LEFT | ISYNTAX_ADJ_TILE_BOTTOM_LEFT | ISYNTAX_ADJ_TILE_BOTTOM_CENTER);
-				child_bottom_left->ll_invalid_edges = invalid_edges & ~(ISYNTAX_ADJ_TILE_CENTER_RIGHT | ISYNTAX_ADJ_TILE_TOP_RIGHT | ISYNTAX_ADJ_TILE_TOP_CENTER);
-				child_bottom_right->ll_invalid_edges = invalid_edges & ~(ISYNTAX_ADJ_TILE_CENTER_LEFT | ISYNTAX_ADJ_TILE_TOP_LEFT | ISYNTAX_ADJ_TILE_TOP_CENTER);
-
-				if (invalid_edges != 0) {
-					console_print("load: scale=%d x=%d y=%d  idwt time =%g  invalid edges=%x\n", scale, tile_x, tile_y, elapsed_idwt, invalid_edges);
-					// early out
-					tile->is_submitted_for_loading = false;
-					release_temp_memory(&temp_memory);
-					return NULL;
-				}
+			if (invalid_edges != 0) {
+				console_print_error("load: scale=%d x=%d y=%d  idwt time =%g  invalid edges=%x\n", scale, tile_x, tile_y, elapsed_idwt, invalid_edges);
+				// early out
+				release_temp_memory(&temp_memory);
+				return NULL;
 			}
 		}
 	}
 
 	tile->is_loaded = true; // Meaning: it is now safe to start loading 'child' tiles of the next level
+	if (!decode_rgb) {
+		release_temp_memory(&temp_memory); // free Y, Co and Cg
+		return NULL;
+	}
 
 	// For the Y (luminance) color channel, we actually need the absolute value of the Y-channel wavelet coefficient.
 	// (This doesn't hold for Co and Cg, those are are used directly as signed integers)
@@ -2606,7 +2613,7 @@ void isyntax_set_work_queue(isyntax_t* isyntax, work_queue_t* work_queue) {
 	isyntax->work_submission_queue = work_queue;
 }
 
-bool isyntax_open(isyntax_t* isyntax, const char* filename) {
+bool isyntax_open(isyntax_t* isyntax, const char* filename, bool init_allocators) {
 
 	console_print_verbose("Attempting to open iSyntax: %s\n", filename);
 	ASSERT(isyntax);
@@ -3068,12 +3075,35 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename) {
 			size_t ll_coeff_block_allocator_capacity_in_blocks = block_allocator_maximum_capacity_in_blocks / 4;
 			size_t h_coeff_block_size = ll_coeff_block_size * 3;
 			size_t h_coeff_block_allocator_capacity_in_blocks = ll_coeff_block_allocator_capacity_in_blocks * 3;
-			isyntax->ll_coeff_block_allocator = block_allocator_create(ll_coeff_block_size, ll_coeff_block_allocator_capacity_in_blocks, MEGABYTES(256));
-			isyntax->h_coeff_block_allocator = block_allocator_create(h_coeff_block_size, h_coeff_block_allocator_capacity_in_blocks, MEGABYTES(256));
+			if (init_allocators) {
+				isyntax->ll_coeff_block_allocator = malloc(sizeof(block_allocator_t));
+				isyntax->h_coeff_block_allocator = malloc(sizeof(block_allocator_t));
+				*isyntax->ll_coeff_block_allocator = block_allocator_create(ll_coeff_block_size, ll_coeff_block_allocator_capacity_in_blocks, MEGABYTES(256));
+				*isyntax->h_coeff_block_allocator = block_allocator_create(h_coeff_block_size, h_coeff_block_allocator_capacity_in_blocks, MEGABYTES(256));
+				isyntax->is_block_allocator_owned = true;
+			} else {
+				// The caller must inject the allocators after return of isyntax_open().
+				isyntax->ll_coeff_block_allocator = NULL;
+				isyntax->h_coeff_block_allocator = NULL;
+				isyntax->is_block_allocator_owned = false;
+			}
 
 			success = true;
 
 			free(read_buffer);
+
+			// Populate debug info.
+			for (int scale = 0; scale < wsi_image->level_count; ++scale) {
+				isyntax_level_t* level = &wsi_image->levels[scale];
+				for (int tile_y = 0; tile_y < level->height_in_tiles; ++tile_y) {
+					for (int tile_x = 0; tile_x < level->width_in_tiles; ++tile_x) {
+						isyntax_tile_t* tile = &level->tiles[level->width_in_tiles * tile_y + tile_x];
+						tile->dbg_tile_scale = scale;
+						tile->dbg_tile_x = tile_x;
+						tile->dbg_tile_y = tile_y;
+					}
+				}
+			}
 		}
 		file_stream_close(fp);
 

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -3100,9 +3100,9 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, bool init_allocators
 				for (int tile_y = 0; tile_y < level->height_in_tiles; ++tile_y) {
 					for (int tile_x = 0; tile_x < level->width_in_tiles; ++tile_x) {
 						isyntax_tile_t* tile = &level->tiles[level->width_in_tiles * tile_y + tile_x];
-						tile->dbg_tile_scale = scale;
-						tile->dbg_tile_x = tile_x;
-						tile->dbg_tile_y = tile_y;
+						tile->tile_scale = scale;
+						tile->tile_x = tile_x;
+						tile->tile_y = tile_y;
 					}
 				}
 			}

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -253,16 +253,22 @@ typedef struct isyntax_tile_t {
 	bool is_submitted_for_loading;
 	bool is_loaded;
 
-    // Caching management.
-    // TODO(avirodov): need to rethink this, maybe an external struct that points to isyntax_tile_t.
+    // Cache management.
+    // TODO(avirodov): need to rethink this, maybe an external struct that points to isyntax_tile_t. The benefit
+    //   is that the cache is usually smaller than the number of tiles. The con is that I'll need to manage list memory
+    //   (probably another allocator for small objects - list nodes).
     bool cache_marked;
     struct isyntax_tile_t* cache_next;
     struct isyntax_tile_t* cache_prev;
 
-    // TODO(avirodov): hide behind compile flag. Useful for debug. Or make proper, useful for marking algorithm too.
-    int dbg_tile_scale;
-    int dbg_tile_x;
-    int dbg_tile_y;
+    // Note(avirodov): this is needed for isyntax_reader. It is very convenient to be able to compute neighbors
+    // from the tile itself, although at the cost of additional memory (3 ints) per tile.
+    // TODO(avirodov): reconsider this as part of moving out cache_* fields, if applicable.
+    // TODO(avirodov): tile_x and tile_y can be computed by O(1) pointer arithmetic given scale. Scale can be
+    //  computed as well, but in O(L) where L is number of levels, and that will be computed often.
+    int tile_scale;
+    int tile_x;
+    int tile_y;
 } isyntax_tile_t;
 
 typedef struct isyntax_level_t {

--- a/src/isyntax/isyntax_reader.c
+++ b/src/isyntax/isyntax_reader.c
@@ -1,7 +1,7 @@
 /*
   BSD 2-Clause License
 
-  Copyright (c) 2019-2023, Pieter Valkema
+  Copyright (c) 2019-2023, Pieter Valkema, Alexandr Virodov
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -26,13 +26,414 @@
 */
 
 #include "common.h"
-#include "isyntax.h"
+#include "isyntax_reader.h"
 
+#define LOG(msg, ...) console_print(msg, ##__VA_ARGS__)
+#define LOG_VAR(fmt, var) console_print("%s: %s=" fmt "\n", __FUNCTION__, #var, var)
 
-
-
-void isyntax_read_region(isyntax_t *isyntax, uint32_t *dest, i64 x, i64 y, i32 level, i64 w, i64 h) {
-
-
+static void tile_list_init(isyntax_tile_list_t* list, const char* dbg_name) {
+    list->head = NULL;
+    list->tail = NULL;
+    list->count = 0;
+    list->dbg_name = dbg_name;
 }
 
+static void tile_list_remove(isyntax_tile_list_t* list, isyntax_tile_t* tile) {
+    if (!tile->cache_next && !tile->cache_prev && !(list->head == tile) && !(list->tail == tile)) {
+        // Not part of any list.
+        return;
+    }
+    if (list->head == tile) {
+        list->head = tile->cache_next;
+    }
+    if (list->tail == tile) {
+        list->tail = tile->cache_prev;
+    }
+    if (tile->cache_prev) {
+        tile->cache_prev->cache_next = tile->cache_next;
+    }
+    if (tile->cache_next) {
+        tile->cache_next->cache_prev = tile->cache_prev;
+    }
+    // Here we assume that the tile is part of this list, but we don't check (O(n)).
+    tile->cache_next = NULL;
+    tile->cache_prev = NULL;
+    list->count--;
+}
+
+static void tile_list_insert_first(isyntax_tile_list_t* list, isyntax_tile_t* tile) {
+    // printf("### tile_list_insert_first %s scale=%d x=%d y=%d\n", list->dbg_name, tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y);
+    ASSERT(tile->cache_next == NULL && tile->cache_prev == NULL);
+    if (list->head == NULL) {
+        list->head = tile;
+        list->tail = tile;
+    } else {
+        list->head->cache_prev = tile;
+        tile->cache_next = list->head;
+        list->head = tile;
+    }
+    list->count++;
+}
+
+static void tile_list_insert_list_first(isyntax_tile_list_t* target_list, isyntax_tile_list_t* source_list) {
+    if (source_list->head == NULL && source_list->tail == NULL) {
+        return;
+    }
+
+    source_list->tail->cache_next = target_list->head;
+    if (target_list->head) {
+        target_list->head->cache_prev = source_list->tail;
+    }
+
+    target_list->head = source_list->head;
+    if (target_list->tail == NULL) {
+        target_list->tail = source_list->tail;
+    }
+    target_list->count += source_list->count;
+    source_list->head = NULL;
+    source_list->tail = NULL;
+    source_list->count = 0;
+}
+
+#define ITERATE_TILE_LIST(_iter, _list) \
+    isyntax_tile_t* _iter = _list.head; _iter; _iter = _iter->cache_next
+
+
+static void isyntax_openslide_load_tile_coefficients_ll_or_h(isyntax_cache_t* cache,
+                                                             isyntax_t* isyntax, isyntax_tile_t* tile,
+                                                             int codeblock_index, bool is_ll) {
+    isyntax_image_t* wsi = &isyntax->images[isyntax->wsi_image_index];
+    isyntax_data_chunk_t* chunk = &wsi->data_chunks[tile->data_chunk_index];
+
+    for (int color = 0; color < 3; ++color) {
+        isyntax_codeblock_t* codeblock = &wsi->codeblocks[codeblock_index + color * chunk->codeblock_count_per_color];
+        ASSERT(codeblock->coefficient == (is_ll ? 0 : 1)); // LL coefficient codeblock for this tile.
+        // TODO(avirodov): int vs i32 vs u32 consistently.
+        ASSERT(codeblock->color_component == (u32)color);
+        ASSERT(codeblock->scale == (u32)tile->dbg_tile_scale);
+        if (is_ll) {
+            tile->color_channels[color].coeff_ll = (icoeff_t *) block_alloc(&cache->ll_coeff_block_allocator);
+        } else {
+            tile->color_channels[color].coeff_h = (icoeff_t *) block_alloc(&cache->h_coeff_block_allocator);
+        }
+        // TODO(avirodov): fancy allocators, for multiple sequential blocks (aka chunk). Or let OS do the caching.
+        u8* codeblock_data = malloc(codeblock->block_size);
+        size_t bytes_read = file_handle_read_at_offset(codeblock_data, isyntax->file_handle,
+                                                       codeblock->block_data_offset, codeblock->block_size);
+        if (!(bytes_read > 0)) {
+            console_print_error("Error: could not read iSyntax data at offset %lld (read size %lld)\n",
+                                codeblock->block_data_offset, codeblock->block_size);
+        }
+
+        isyntax_hulsken_decompress(codeblock_data, codeblock->block_size,
+                                   isyntax->block_width, isyntax->block_height,
+                                   codeblock->coefficient, 1,
+                                   is_ll ? tile->color_channels[color].coeff_ll : tile->color_channels[color].coeff_h);
+        free(codeblock_data);
+    }
+
+    if (is_ll) {
+        tile->has_ll = true;
+    } else {
+        tile->has_h = true;
+    }
+}
+
+static void isyntax_openslide_load_tile_coefficients(isyntax_cache_t* cache, isyntax_t* isyntax, isyntax_tile_t* tile) {
+    isyntax_image_t* wsi = &isyntax->images[isyntax->wsi_image_index];
+
+    if (!tile->exists) {
+        return;
+    }
+
+    // Load LL codeblocks here only for top-level tiles. For other levels, the LL coefficients are computed from parent
+    // tiles later on.
+    if (!tile->has_ll && tile->dbg_tile_scale == wsi->max_scale) {
+        isyntax_openslide_load_tile_coefficients_ll_or_h(
+                cache, isyntax, tile, /*codeblock_index=*/tile->codeblock_index, /*is_ll=*/true);
+    }
+
+    if (!tile->has_h) {
+        ASSERT(tile->exists);
+        isyntax_data_chunk_t* chunk = wsi->data_chunks + tile->data_chunk_index;
+
+        i32 scale_in_chunk = chunk->scale - tile->dbg_tile_scale;
+        ASSERT(scale_in_chunk >= 0 && scale_in_chunk < 3);
+        i32 codeblock_index_in_chunk = 0;
+        if (scale_in_chunk == 0) {
+            codeblock_index_in_chunk = 0;
+        } else if (scale_in_chunk == 1) {
+            codeblock_index_in_chunk = 1 + (tile->dbg_tile_y % 2) * 2 + (tile->dbg_tile_x % 2);
+        } else if (scale_in_chunk == 2) {
+            codeblock_index_in_chunk = 5 + (tile->dbg_tile_y % 4) * 4 + (tile->dbg_tile_x % 4);
+        } else {
+            panic();
+        }
+
+        isyntax_openslide_load_tile_coefficients_ll_or_h(
+                cache, isyntax, tile,
+                /*codeblock_index=*/tile->codeblock_chunk_index + codeblock_index_in_chunk, /*is_ll=*/false);
+    }
+}
+
+typedef union isyntax_tile_children_t {
+    struct {
+        isyntax_tile_t *child_top_left;
+        isyntax_tile_t *child_top_right;
+        isyntax_tile_t *child_bottom_left;
+        isyntax_tile_t *child_bottom_right;
+    };
+    isyntax_tile_t* as_array[4];
+} isyntax_tile_children_t;
+
+static isyntax_tile_children_t isyntax_openslide_compute_children(isyntax_t* isyntax, isyntax_tile_t* tile) {
+    isyntax_tile_children_t result;
+    isyntax_image_t* wsi = &isyntax->images[isyntax->wsi_image_index];
+    ASSERT(tile->dbg_tile_scale > 0);
+    isyntax_level_t *next_level = &wsi->levels[tile->dbg_tile_scale - 1];
+    result.child_top_left = next_level->tiles + (tile->dbg_tile_y * 2) * next_level->width_in_tiles + (tile->dbg_tile_x * 2);
+    result.child_top_right = result.child_top_left + 1;
+    result.child_bottom_left = result.child_top_left + next_level->width_in_tiles;
+    result.child_bottom_right = result.child_bottom_left + 1;
+    return result;
+}
+
+
+static uint32_t* isyntax_openslide_idwt(isyntax_cache_t* cache, isyntax_t* isyntax, isyntax_tile_t* tile,
+                                        bool return_rgb) {
+    if (tile->dbg_tile_scale == 0) {
+        ASSERT(return_rgb); // Shouldn't be asking for idwt at level 0 if we're not going to use the result for pixels.
+        return isyntax_load_tile(isyntax, &isyntax->images[isyntax->wsi_image_index],
+                                 tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y,
+                                 &cache->ll_coeff_block_allocator, /*decode_rgb=*/true);
+    }
+
+    if (return_rgb) {
+        // TODO(avirodov): if we want rgb from tile where idwt was done already, this could be cheaper if we store
+        //  the lls in the tile. Currently need to recompute idwt.
+        return isyntax_load_tile(isyntax, &isyntax->images[isyntax->wsi_image_index],
+                                 tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y,
+                                 &cache->ll_coeff_block_allocator, /*decode_rgb=*/true);
+    }
+
+    // If all children have ll coefficients and we don't need the rgb pixels, no need to do the idwt.
+    ASSERT(!return_rgb && tile->dbg_tile_scale > 0);
+    isyntax_tile_children_t children = isyntax_openslide_compute_children(isyntax, tile);
+    if (children.child_top_left->has_ll && children.child_top_right->has_ll &&
+        children.child_bottom_left->has_ll && children.child_bottom_right->has_ll) {
+        return NULL;
+    }
+
+    isyntax_load_tile(isyntax, &isyntax->images[isyntax->wsi_image_index],
+                      tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y,
+                      &cache->ll_coeff_block_allocator, /*decode_rgb=*/false);
+    return NULL;
+}
+
+static void isyntax_make_tile_lists_add_parent_to_list(isyntax_t* isyntax, isyntax_tile_t* tile,
+                                                       isyntax_tile_list_t* idwt_list, isyntax_tile_list_t* cache_list) {
+    isyntax_image_t* wsi = &isyntax->images[isyntax->wsi_image_index];
+    int parent_tile_scale = tile->dbg_tile_scale + 1;
+    if (parent_tile_scale > wsi->max_scale) {
+        return;
+    }
+
+    int parent_tile_x = tile->dbg_tile_x / 2;
+    int parent_tile_y = tile->dbg_tile_y / 2;
+    isyntax_level_t* parent_level = &wsi->levels[parent_tile_scale];
+    isyntax_tile_t* parent_tile = &parent_level->tiles[parent_level->width_in_tiles * parent_tile_y + parent_tile_x];
+    if (parent_tile->exists && !parent_tile->cache_marked) {
+        tile_list_remove(cache_list, parent_tile);
+        parent_tile->cache_marked = true;
+        tile_list_insert_first(idwt_list, parent_tile);
+    }
+}
+
+static void isyntax_make_tile_lists_add_children_to_list(isyntax_t* isyntax, isyntax_tile_t* tile,
+                                                         isyntax_tile_list_t* children_list, isyntax_tile_list_t* cache_list) {
+    if (tile->dbg_tile_scale > 0) {
+        isyntax_tile_children_t children = isyntax_openslide_compute_children(isyntax, tile);
+        for (int i = 0; i < 4; ++i) {
+            if (!children.as_array[i]->cache_marked) {
+                tile_list_remove(cache_list, children.as_array[i]);
+                tile_list_insert_first(children_list, children.as_array[i]);
+            }
+        }
+    }
+}
+
+static void isyntax_make_tile_lists_by_scale(isyntax_t* isyntax, int start_scale,
+                                             isyntax_tile_list_t* idwt_list,
+                                             isyntax_tile_list_t* coeff_list,
+                                             isyntax_tile_list_t* children_list,
+                                             isyntax_tile_list_t* cache_list) {
+    isyntax_image_t* wsi = &isyntax->images[isyntax->wsi_image_index];
+    for (int scale = start_scale; scale <= wsi->max_scale; ++scale) {
+        // Mark all neighbors of idwt tiles at this level as requiring coefficients.
+        isyntax_level_t* level = &wsi->levels[scale];
+        for (ITERATE_TILE_LIST(tile, (*idwt_list))) {
+            if (tile->dbg_tile_scale == scale) {
+                for (int y_offset = -1; y_offset <= 1; ++y_offset) {
+                    for (int x_offset = -1; x_offset <= 1; ++ x_offset) {
+                        int neighbor_tile_x =  tile->dbg_tile_x + x_offset;
+                        int neighbor_tile_y = tile->dbg_tile_y + y_offset;
+                        if (neighbor_tile_x < 0 || neighbor_tile_x >= level->width_in_tiles ||
+                            neighbor_tile_y < 0 || neighbor_tile_y >= level->height_in_tiles) {
+                            continue;
+                        }
+
+                        isyntax_tile_t* neighbor_tile = &level->tiles[level->width_in_tiles * neighbor_tile_y + neighbor_tile_x];
+                        if (neighbor_tile->cache_marked || !neighbor_tile->exists) {
+                            continue;
+                        }
+
+                        tile_list_remove(cache_list, neighbor_tile);
+                        neighbor_tile->cache_marked = true;
+                        tile_list_insert_first(coeff_list, neighbor_tile);
+                    }
+                }
+            }
+        }
+
+        // Mark all parents of tiles at this level as requiring idwt. This way all tiles at this level will get their
+        // ll coefficients.
+        for (ITERATE_TILE_LIST(tile, (*idwt_list))) {
+            if (tile->dbg_tile_scale == scale) {
+                isyntax_make_tile_lists_add_parent_to_list(isyntax, tile, idwt_list, cache_list);
+            }
+        }
+        for (ITERATE_TILE_LIST(tile, (*coeff_list))) {
+            if (tile->dbg_tile_scale == scale) {
+                isyntax_make_tile_lists_add_parent_to_list(isyntax, tile, idwt_list, cache_list);
+            }
+        }
+    }
+
+    // Add all children of idwt that were not yet handled. The children will have their ll coefficients written,
+    // and so should be cache bumped.
+    // TODO(avirodov): if we store the idwt result (ll of next level) in the tile instead of the children, this
+    //  would be unnecessary. But I'm not sure this is bad either.
+    for (ITERATE_TILE_LIST(tile, (*idwt_list))) {
+        isyntax_make_tile_lists_add_children_to_list(isyntax, tile, children_list, cache_list);
+    }
+}
+
+uint32_t* isyntax_read_tile_bgra(isyntax_cache_t* cache, isyntax_t* isyntax, int scale, int tile_x, int tile_y) {
+    // TODO(avirodov): more granular locking (some notes below). This will require handling overlapping work, that is
+    //  thread A needing tile 123 and started to load it, and thread B needing same tile 123 and needs to wait for A.
+    // TODO(avirodov): g_autoptr(GMutexLocker) locker G_GNUC_UNUSED = g_mutex_locker_new(&cache->mutex);
+
+    isyntax_image_t* wsi = &isyntax->images[isyntax->wsi_image_index];
+    isyntax_level_t* level = &wsi->levels[scale];
+    isyntax_tile_t *tile = &level->tiles[level->width_in_tiles * tile_y + tile_x];
+    // printf("=== isyntax_openslide_load_tile scale=%d tile_x=%d tile_y=%d\n", scale, tile_x, tile_y);
+    if (!tile->exists) {
+        uint32_t* rgba = malloc(isyntax->tile_width * isyntax->tile_height * 4);
+        memset(rgba, 0xff, isyntax->tile_width * isyntax->tile_height * 4);
+        return rgba;
+    }
+
+    // Need 3 lists:
+    // 1. idwt list - those tiles will have to perform an idwt for their children to get ll coeffs. Primary cache bump.
+    // 2. coeff list - those tiles are neighbors and will need to have coefficients loaded. Secondary cache bump.
+    // 3. children list - those tiles will have their ll coeffs loaded as a side effect. Tertiary cache bump.
+    // Those lists must be disjoint, and sorted such that parents are closer to head than children.
+    isyntax_tile_list_t idwt_list = {NULL, NULL, 0, "idwt_list"};
+    isyntax_tile_list_t coeff_list = {NULL, NULL, 0, "coeff_list"};
+    isyntax_tile_list_t children_list = {NULL, NULL, 0, "children_list"};
+
+    // Lock.
+    // Make a list of all dependent tiles (including the required one).
+    // Mark all dependent tiles as "reserved" so that they are not evicted by other threads as we load them.
+    // Unlock.
+    {
+        tile_list_remove(&cache->cache_list, tile);
+        tile->cache_marked = true;
+        tile_list_insert_first(&idwt_list, tile);
+    }
+    isyntax_make_tile_lists_by_scale(isyntax, scale, &idwt_list, &coeff_list, &children_list, &cache->cache_list);
+
+    // Unmark visit status and reserve all nodes. todo(avirodov): reserve later when doing threading.
+    for (ITERATE_TILE_LIST(tile, idwt_list))     { tile->cache_marked = false; /*printf("@@@ idwt_list tile scale=%d x=%d y=%d\n", tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y);*/ }
+    for (ITERATE_TILE_LIST(tile, coeff_list))    { tile->cache_marked = false; /*printf("@@@ coeff_list tile scale=%d x=%d y=%d\n", tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y);*/ }
+    for (ITERATE_TILE_LIST(tile, children_list)) { tile->cache_marked = false; /*printf("@@@ children_list tile scale=%d x=%d y=%d\n", tile->dbg_tile_scale, tile->dbg_tile_x, tile->dbg_tile_y);*/ }
+
+    // IO+decode: For all dependent tiles, read and decode coefficients where missing (hh, and ll for top tiles).
+    // Assuming lists are sorted parents first.
+    // IDWT as needed, top to bottom. This should produce idwt for this tile as well, which should be last in idwt list.
+    // YCoCb->RGB for this tile only.
+    uint32_t* result = NULL;
+    for (ITERATE_TILE_LIST(tile, coeff_list)) {
+        isyntax_openslide_load_tile_coefficients(cache, isyntax, tile);
+    }
+    for (ITERATE_TILE_LIST(tile, idwt_list)) {
+        isyntax_openslide_load_tile_coefficients(cache, isyntax, tile);
+    }
+    for (ITERATE_TILE_LIST(tile, idwt_list)) {
+        if (tile == idwt_list.tail) {
+            result = isyntax_openslide_idwt(cache, isyntax, tile, /*return_rgb=*/true);
+        } else {
+            isyntax_openslide_idwt(cache, isyntax, tile, /*return_rgb=*/false);
+        }
+    }
+
+    // Lock.
+    // Bump all the affected tiles in cache.
+    // Unmark all dependent tiles as "referenced" so that they can be evicted.
+    // Perform cache trim (possibly not every invocation).
+    // Unlock.
+
+    tile_list_insert_list_first(&cache->cache_list, &children_list);
+    tile_list_insert_list_first(&cache->cache_list, &coeff_list);
+    tile_list_insert_list_first(&cache->cache_list, &idwt_list);
+
+    // Cache trim. Since we have the result already, it is possible that tiles from this run will be trimmed here
+    // if cache is small or work happened on other threads.
+    // TODO(avirodov): later will need to skip tiles that are reserved by other threads.
+    while (cache->cache_list.count > cache->target_cache_size) {
+        isyntax_tile_t* tile = cache->cache_list.tail;
+        tile_list_remove(&cache->cache_list, tile);
+        for (int i = 0; i < 3; ++i) {
+            if (tile->has_ll) {
+                block_free(&cache->ll_coeff_block_allocator, tile->color_channels[i].coeff_ll);
+                tile->color_channels[i].coeff_ll = NULL;
+            }
+            if (tile->has_h) {
+                block_free(&cache->h_coeff_block_allocator, tile->color_channels[i].coeff_h);
+                tile->color_channels[i].coeff_h = NULL;
+            }
+        }
+        tile->has_ll = false;
+        tile->has_h = false;
+    }
+
+    return result;
+}
+
+isyntax_cache_t* isyntax_make_cache(const char* dbg_name, int cache_size, int block_width, int block_height) {
+    isyntax_cache_t* cache_ptr = malloc(sizeof(isyntax_cache_t));
+    tile_list_init(&cache_ptr->cache_list, dbg_name);
+    cache_ptr->target_cache_size = cache_size;
+    // TODO(avirodov): g_mutex_init(&cache_ptr->mutex);
+
+    cache_ptr->allocator_block_width = block_width;
+    cache_ptr->allocator_block_height = block_height;
+    size_t ll_coeff_block_size = block_width * block_height * sizeof(icoeff_t);
+    size_t block_allocator_maximum_capacity_in_blocks = GIGABYTES(32) / ll_coeff_block_size;
+    size_t ll_coeff_block_allocator_capacity_in_blocks = block_allocator_maximum_capacity_in_blocks / 4;
+    size_t h_coeff_block_size = ll_coeff_block_size * 3;
+    size_t h_coeff_block_allocator_capacity_in_blocks = ll_coeff_block_allocator_capacity_in_blocks * 3;
+    cache_ptr->ll_coeff_block_allocator = block_allocator_create(ll_coeff_block_size, ll_coeff_block_allocator_capacity_in_blocks, MEGABYTES(256));
+    cache_ptr->h_coeff_block_allocator = block_allocator_create(h_coeff_block_size, h_coeff_block_allocator_capacity_in_blocks, MEGABYTES(256));
+    return cache_ptr;
+}
+
+void isyntax_destroy_and_free_cache(isyntax_cache_t* cache) {
+    if (cache->ll_coeff_block_allocator.is_valid) {
+        block_allocator_destroy(&cache->ll_coeff_block_allocator);
+    }
+    if (cache->h_coeff_block_allocator.is_valid) {
+        block_allocator_destroy(&cache->h_coeff_block_allocator);
+    }
+    free(cache);
+}

--- a/src/isyntax/isyntax_reader.c
+++ b/src/isyntax/isyntax_reader.c
@@ -38,7 +38,7 @@ static void tile_list_init(isyntax_tile_list_t* list, const char* dbg_name) {
     list->dbg_name = dbg_name;
 }
 
-static void tile_list_remove(isyntax_tile_list_t* list, isyntax_tile_t* tile) {
+void tile_list_remove(isyntax_tile_list_t* list, isyntax_tile_t* tile) {
     if (!tile->cache_next && !tile->cache_prev && !(list->head == tile) && !(list->tail == tile)) {
         // Not part of any list.
         return;

--- a/src/isyntax/isyntax_reader.h
+++ b/src/isyntax/isyntax_reader.h
@@ -25,3 +25,5 @@ typedef struct isyntax_cache_t {
 isyntax_cache_t* isyntax_make_cache(const char* dbg_name, int cache_size, int block_width, int block_height);
 void isyntax_destroy_and_free_cache(isyntax_cache_t* cache);
 uint32_t* isyntax_read_tile_bgra(isyntax_cache_t* cache, isyntax_t* isyntax, int scale, int tile_x, int tile_y);
+
+void tile_list_remove(isyntax_tile_list_t* list, isyntax_tile_t* tile);

--- a/src/isyntax/isyntax_reader.h
+++ b/src/isyntax/isyntax_reader.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "isyntax.h"
+
+typedef struct isyntax_tile_list_t {
+    isyntax_tile_t* head;
+    isyntax_tile_t* tail;
+    int count;
+    const char* dbg_name;
+} isyntax_tile_list_t;
+
+typedef struct isyntax_cache_t {
+    isyntax_tile_list_t cache_list;
+    // TODO(avirodov): GMutex mutex;
+    // TODO(avirodov): int refcount;
+    int target_cache_size;
+    block_allocator_t ll_coeff_block_allocator;
+    block_allocator_t h_coeff_block_allocator;
+    int allocator_block_width;
+    int allocator_block_height;
+} isyntax_cache_t;
+
+// TODO(avirodov): currently it is up to the caller to mutex-lock the cache while calling isyntax_read_tile_bgra().
+// TODO(avirodov): scale probably should be called 'level' in API, and need to resolve clash with current 'level' variables in implementation. Or leave it scale?
+isyntax_cache_t* isyntax_make_cache(const char* dbg_name, int cache_size, int block_width, int block_height);
+void isyntax_destroy_and_free_cache(isyntax_cache_t* cache);
+uint32_t* isyntax_read_tile_bgra(isyntax_cache_t* cache, isyntax_t* isyntax, int scale, int tile_x, int tile_y);

--- a/src/isyntax/isyntax_reader.h
+++ b/src/isyntax/isyntax_reader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "isyntax.h"
+#include "benaphore.h"
 
 typedef struct isyntax_tile_list_t {
     isyntax_tile_t* head;
@@ -11,7 +12,7 @@ typedef struct isyntax_tile_list_t {
 
 typedef struct isyntax_cache_t {
     isyntax_tile_list_t cache_list;
-    // TODO(avirodov): GMutex mutex;
+    benaphore_t mutex;
     // TODO(avirodov): int refcount;
     int target_cache_size;
     block_allocator_t ll_coeff_block_allocator;
@@ -20,10 +21,7 @@ typedef struct isyntax_cache_t {
     int allocator_block_height;
 } isyntax_cache_t;
 
-// TODO(avirodov): currently it is up to the caller to mutex-lock the cache while calling isyntax_read_tile_bgra().
-// TODO(avirodov): scale probably should be called 'level' in API, and need to resolve clash with current 'level' variables in implementation. Or leave it scale?
-isyntax_cache_t* isyntax_make_cache(const char* dbg_name, int cache_size, int block_width, int block_height);
-void isyntax_destroy_and_free_cache(isyntax_cache_t* cache);
-uint32_t* isyntax_read_tile_bgra(isyntax_cache_t* cache, isyntax_t* isyntax, int scale, int tile_x, int tile_y);
+uint32_t* isyntax_read_tile_bgra(isyntax_t* isyntax, isyntax_cache_t* cache, int scale, int tile_x, int tile_y);
 
+void tile_list_init(isyntax_tile_list_t* list, const char* dbg_name);
 void tile_list_remove(isyntax_tile_list_t* list, isyntax_tile_t* tile);

--- a/src/isyntax_example.c
+++ b/src/isyntax_example.c
@@ -30,19 +30,19 @@ void print_isyntax_levels(isyntax_t* isyntax) {
 
 int main(int argc, char** argv) {
 
-	if (argc <= 1) {
+    if (argc <= 1) {
         printf("Usage: %s <isyntax_file> - show levels & tiles.\n"
                "       %s <isyntax_file> <level> <tile_x> <tile_y> <output.png> - write a tile to output.png",
                argv[0], argv[0]);
-		return 0;
-	}
+        return 0;
+    }
 
-	char* filename = argv[1];
+    char* filename = argv[1];
 
     libisyntax_init();
 
-	isyntax_t* isyntax;
-	if (libisyntax_open(filename, /*is_init_allocators=*/0, &isyntax) != LIBISYNTAX_OK) {
+    isyntax_t* isyntax;
+    if (libisyntax_open(filename, /*is_init_allocators=*/0, &isyntax) != LIBISYNTAX_OK) {
         printf("Failed to open %s\n", filename);
         return -1;
     }
@@ -86,5 +86,5 @@ int main(int argc, char** argv) {
     }
 
     libisyntax_close(isyntax);
-	return 0;
+    return 0;
 }

--- a/src/isyntax_example.c
+++ b/src/isyntax_example.c
@@ -1,38 +1,89 @@
 #include "common.h"
+#include "isyntax/isyntax_reader.h"
 
-#include "isyntax.h"
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "third_party/stb_image_write.h"
+
+// TODO(avirodov): libisyntax_init()? not sure who has to call the per-thread init, need discussion.
+#include "platform/platform.h"  // for get_system_info(..), init_thread_memory(..)
+
 
 #define LOG_VAR(fmt, var) printf("%s: %s=" fmt "\n", __FUNCTION__, #var, var)
+
+uint32_t bgra_to_rgba(uint32_t val) {
+    return ((val & 0xff) << 16) | (val & 0x00ff00) | ((val & 0xff0000) >> 16) | (val & 0xff000000);
+}
+
+void print_isyntax_levels(isyntax_t* isyntax) {
+    int wsi_image_idx = isyntax->wsi_image_index;
+    LOG_VAR("%d", wsi_image_idx);
+    isyntax_image_t* wsi_image = &isyntax->images[wsi_image_idx];
+    isyntax_level_t* levels = wsi_image->levels;
+
+    for (int i = 0; i < wsi_image->level_count; ++i) {
+        LOG_VAR("%d", i);
+        LOG_VAR("%d", levels[i].scale);
+        LOG_VAR("%d", levels[i].width_in_tiles);
+        LOG_VAR("%d", levels[i].height_in_tiles);
+    }
+}
 
 int main(int argc, char** argv) {
 
 	if (argc <= 1) {
         printf("Usage: %s <isyntax_file> - show levels & tiles.\n"
-               "       %s <isyntax_file> <scale> <tile_x> <tile_y> <output.png> - write a tile to output.png",
+               "       %s <isyntax_file> <level> <tile_x> <tile_y> <output.png> - write a tile to output.png",
                argv[0], argv[0]);
 		return 0;
 	}
 
 	char* filename = argv[1];
 
+    get_system_info(/*verbose=*/true);
+    init_thread_memory(0);
+
 	isyntax_t isyntax = {0};
-	if (isyntax_open(&isyntax, filename)) {
-		printf("Successfully opened %s\n", filename);
+	if (!isyntax_open(&isyntax, filename, /*init_allocators=*/false)) {
+        printf("Failed to open %s\n", filename);
+        return -1;
+    }
+    printf("Successfully opened %s\n", filename);
 
-        int wsi_image_idx = isyntax.wsi_image_index;
-        LOG_VAR("%d", wsi_image_idx);
-        isyntax_image_t* wsi_image = &isyntax.images[wsi_image_idx];
-        isyntax_level_t* levels = wsi_image->levels;
+    if (argc <= 5) {
+        print_isyntax_levels(&isyntax);
+    } else {
+        int level = atoi(argv[2]);
+        int tile_x = atoi(argv[3]);
+        int tile_y = atoi(argv[4]);
+        const char* output_png = argv[5];
 
-        for (int i = 0; i < wsi_image->level_count; ++i) {
-            LOG_VAR("%d", i);
-            LOG_VAR("%d", levels[i].scale);
-            LOG_VAR("%d", levels[i].width_in_tiles);
-            LOG_VAR("%d", levels[i].height_in_tiles);
+        LOG_VAR("%d", level);
+        LOG_VAR("%d", tile_x);
+        LOG_VAR("%d", tile_y);
+        LOG_VAR("%s", output_png);
+
+        isyntax_cache_t *isyntax_cache = isyntax_make_cache("example_cache", 2000,
+                                                            isyntax.block_width, isyntax.block_height);
+        // Allocators must be null because we asked to not init_allocators in isyntax_open().
+        assert(isyntax.h_coeff_block_allocator == NULL);
+        assert(isyntax.ll_coeff_block_allocator == NULL);
+        isyntax.ll_coeff_block_allocator = &isyntax_cache->ll_coeff_block_allocator;
+        isyntax.h_coeff_block_allocator = &isyntax_cache->h_coeff_block_allocator;
+        isyntax.is_block_allocator_owned = false;
+
+        uint32_t *pixels = isyntax_read_tile_bgra(isyntax_cache, &isyntax, level, tile_x, tile_y);
+
+        // convert data to the correct pixel format (bgra->rgba).
+        for (int i = 0; i < isyntax.tile_height * isyntax.tile_width; ++i) {
+            pixels[i] = bgra_to_rgba(pixels[i]);
         }
+        printf("Writing %s...\n", output_png);
+        stbi_write_png(output_png, isyntax.tile_width, isyntax.tile_height, 4, pixels, isyntax.tile_width * 4);
+        printf("Done writing %s.\n", output_png);
 
-        isyntax_destroy(&isyntax);
-	}
+        isyntax_destroy_and_free_cache(isyntax_cache);
+    }
 
+    isyntax_destroy(&isyntax);
 	return 0;
 }

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -1,3 +1,68 @@
 #pragma once
 
-void libisyntax_init();
+#include <stdint.h>
+
+// API conventions:
+// - return type is one of:
+// -- appropriate data type for simple getters. For complex getters doing work, isyntax_error_t + out variable.
+// -- void if the function doesn't fail at runtime (e.g. destructors).
+// -- isyntax_error_t otherwise.
+// - Output arguments are last, name prefixed with 'out_'.
+// - 'Object operated on' argument is first.
+// - Function names are prefixed with 'libisyntax_', as C doesn't have namespaces. Naming convention
+//   is: libisyntax_<object>_<action>(..), where <object> is omitted for the object representing the isyntax file.
+// - Functions don't check for null/out of bounds, for efficiency. (they may assert, but that is implementation detail).
+// - Booleans are represented as int32_t and prefxied with 'is_' or 'has_'.
+// - Const applied to pointers is used as a signal that the object will not be modified.
+// - Prefer int even for unsigned types, see java rationale.
+
+
+typedef int32_t isyntax_error_t;
+
+#define LIBISYNTAX_OK 0
+// Generic error that the user should not expect to recover from.
+#define LIBISYNTAX_FATAL 1
+// One of the arguments passed to a function is invalid.
+#define LIBISYNTAX_INVALID_ARGUMENT 2
+
+typedef struct isyntax_t isyntax_t;
+typedef struct isyntax_image_t isyntax_image_t;
+typedef struct isyntax_level_t isyntax_level_t;
+typedef struct isyntax_cache_t isyntax_cache_t;
+
+//== Common API ==
+isyntax_error_t libisyntax_init();
+isyntax_error_t libisyntax_open(const char* filename, int32_t is_init_allocators, isyntax_t** out_isyntax);
+void            libisyntax_close(isyntax_t* isyntax);
+
+//== Getters API ==
+int32_t                libisyntax_get_tile_width(const isyntax_t* isyntax);
+int32_t                libisyntax_get_tile_height(const isyntax_t* isyntax);
+int32_t                libisyntax_get_wsi_image_index(const isyntax_t* isyntax);
+const isyntax_image_t* libisyntax_get_image(const isyntax_t* isyntax, int32_t wsi_image_index);
+int32_t                libisyntax_image_get_level_count(const isyntax_image_t* image);
+const isyntax_level_t* libisyntax_image_get_level(const isyntax_image_t* image, int32_t index);
+
+int32_t                libisyntax_level_get_scale(const isyntax_level_t* level);
+int32_t                libisyntax_level_get_width_in_tiles(const isyntax_level_t* level);
+int32_t                libisyntax_level_get_height_in_tiles(const isyntax_level_t* level);
+
+//== Cache API ==
+isyntax_error_t libisyntax_cache_create(const char* debug_name_or_null, int32_t cache_size,
+                                        isyntax_cache_t** out_isyntax_cache);
+// Note: returns LIBISYNTAX_INVALID_ARGUMENT  if isyntax_to_inject was not initialized with is_init_allocators = 0.
+// TODO(avirodov): this function will fail if the isyntax object has different block size than the first isyntax injected.
+//  Block size variation was not observed in practice, and a proper fix may include supporting multiple block sizes
+//  within isyntax_cache_t implementation.
+isyntax_error_t libisyntax_cache_inject(isyntax_cache_t* isyntax_cache, isyntax_t* isyntax);
+void            libisyntax_cache_destroy(isyntax_cache_t* isyntax_cache);
+
+
+//== Tile API ==
+// Note: pixels are in BGRA layout.
+// Note: must use libisyntax_tile_free_pixels() to free out_pixels.
+isyntax_error_t libisyntax_tile_read(isyntax_t* isyntax, isyntax_cache_t* isyntax_cache,
+                                     int32_t level, int64_t tile_x, int64_t tile_y, uint32_t** out_pixels);
+void            libisyntax_tile_free_pixels(uint32_t* pixels);
+
+


### PR DESCRIPTION
Hello Peter, I would like to actually merge this PR please, with your approval.

This has a few parts that are hard to separate, so I'm making it as one big PR unfortunately. Parts:
1. Modifications to internal isyntax function interfaces and logic to support cached tile reader.
2. Cached tile reader implementation.
3. Proper API/ABI in libisyntax.h and implementation in libisyntax.c.
4. The example using all the above.

As discussed in other PRs, this changes e.g. isyntax_open, so it will require changes to isyntax_streamer.c and slidescape, and I have not done these changes. So your build will probably break after merge. Please let me know if you prefer to handle it differently than merging & fixing.