### PR TITLE
Added NEON versions

### DIFF
--- a/src/platform/intrinsics.h
+++ b/src/platform/intrinsics.h
@@ -249,10 +249,7 @@ static inline u64 maybe_swap_64(u64 x, bool32 is_big_endian) {
 
 #if APPLE_ARM
 static inline i32 popcount(u32 x) {
-    int c = 0;
-    for (; x != 0; x &= x - 1)
-        c++;
-    return c;
+    return __builtin_popcount(x);
 }
 #elif COMPILER_MSVC
 static inline i32 popcount(u32 x) {

--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -104,7 +104,7 @@ void get_system_info(bool verbose) {
 	sysctlbyname("hw.logicalcpu", &logical_cpu_count, &logical_cpu_count_len, NULL, 0);
 	os_page_size = (u32) getpagesize();
 	page_alignment_mask = ~((u64)(sysconf(_SC_PAGE_SIZE) - 1));
-	is_macos = true;
+	bool is_macos = true;
 #elif LINUX
     logical_cpu_count = sysconf( _SC_NPROCESSORS_ONLN );
     physical_cpu_count = logical_cpu_count; // TODO: how to read this on Linux?


### PR DESCRIPTION
I have added a few NEON instructions which were missing. There was also a bool missing somewhere in `is_macos`. Is this actually used?