### PR TITLE
NEON support for convert_ycocg_to_bgra_block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)")
+    message(STATUS "Enabling ARM NEON support")
+    add_compile_options(-mfpu=neon)
+endif()
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 include_directories("${CMAKE_SOURCE_DIR}/src")


### PR DESCRIPTION
As requested. By the way, this assumes the tile_size is divisible by 8. I assume this will be always fine, but we never check for this (maybe an assert?)