### PR TITLE
Change offset to pixels

### DIFF
--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -3063,20 +3063,22 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, bool init_allocators
 
 						}
 
-						// When recursively decoding the tiles, at each iteration the image is slightly offset
-						// to the top left.
+                        // When recursively decoding the tiles, at each iteration the image is slightly offset
+                        // to the top left.
                         // The amount of shift seems correspond to the level padding: ((3 >> (scale-1)) - 2).
-						// (I guess this is related to the way the wavelet transform works.)
-						// Put another way: the highest (zoomed out levels) are shifted the to the bottom right
-						// (this is also reflected in the x and y coordinates of the codeblocks in the iSyntax header).
-						for (i32 scale = 1; scale < wsi_image->level_count; ++scale) {
-							isyntax_level_t* level = wsi_image->levels + scale;
+                        // (I guess this is related to the way the wavelet transform works.)
+                        // Put another way: the highest (zoomed out levels) are shifted the to the bottom right
+                        // (this is also reflected in the x and y coordinates of the codeblocks in the iSyntax header).
+                        for (i32 scale = 0; scale < wsi_image->level_count; ++scale) {
+                            isyntax_level_t* level = wsi_image->levels + scale;
+                            level->origin_offset_in_pixels = ((PER_LEVEL_PADDING << wsi_image->level_count) - PER_LEVEL_PADDING) >> scale;
+                            level->width = wsi_image->width >> scale;
+                            level->height = wsi_image->height >> scale;
                             float offset_in_pixels = (float) (get_first_valid_coef_pixel(scale - 1));
-                            level->origin_offset_in_pixels = offset_in_pixels;
-							float offset_in_um_x = offset_in_pixels * wsi_image->levels[0].um_per_pixel_x;
-							float offset_in_um_y = offset_in_pixels * wsi_image->levels[0].um_per_pixel_y;
-							level->origin_offset = (v2f){offset_in_um_x, offset_in_um_y};
-						}
+                            float offset_in_um_x = offset_in_pixels * wsi_image->levels[0].um_per_pixel_x;
+                            float offset_in_um_y = offset_in_pixels * wsi_image->levels[0].um_per_pixel_y;
+                            level->origin_offset = (v2f){offset_in_um_x, offset_in_um_y};
+                        }
 
 						parse_ticks_elapsed += (get_clock() - parse_begin);
 //						console_print("iSyntax: the seektable is %u bytes, or %g%% of the total file size\n", seektable_size, (float)((float)seektable_size * 100.0f) / isyntax->filesize);

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -272,19 +272,21 @@ typedef struct isyntax_tile_t {
 } isyntax_tile_t;
 
 typedef struct isyntax_level_t {
-	i32 scale;
-	i32 width_in_tiles;
-	i32 height_in_tiles;
-	float downsample_factor;
-	float um_per_pixel_x;
-	float um_per_pixel_y;
-	float x_tile_side_in_um;
-	float y_tile_side_in_um;
-	u64 tile_count;
-	float origin_offset_in_pixels;
-	v2f origin_offset;
-	isyntax_tile_t* tiles;
-	bool is_fully_loaded;
+    i32 scale;
+    i32 width_in_tiles;
+    i32 height_in_tiles;
+    u64 width;
+    u64 height;
+    float downsample_factor;
+    float um_per_pixel_x;
+    float um_per_pixel_y;
+    float x_tile_side_in_um;
+    float y_tile_side_in_um;
+    u64 tile_count;
+    i32 origin_offset_in_pixels;
+    v2f origin_offset;
+    isyntax_tile_t* tiles;
+    bool is_fully_loaded;
 } isyntax_level_t;
 
 typedef struct isyntax_image_t {

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -226,6 +226,22 @@ int32_t libisyntax_level_get_height_in_tiles(const isyntax_level_t* level) {
     return level->height_in_tiles;
 }
 
+int32_t libisyntax_level_get_width(const isyntax_level_t* level) {
+    return level->width;
+}
+
+int32_t libisyntax_level_get_height(const isyntax_level_t* level) {
+    return level->height;
+}
+
+float libisyntax_level_get_mpp_x(const isyntax_level_t* level) {
+    return level->um_per_pixel_x;
+}
+
+float libisyntax_level_get_mpp_y(const isyntax_level_t* level) {
+    return level->um_per_pixel_y;
+}
+
 isyntax_error_t libisyntax_cache_create(const char* debug_name_or_null, int32_t cache_size,
                                         isyntax_cache_t** out_isyntax_cache)
 {

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -46,6 +46,10 @@ const isyntax_level_t* libisyntax_image_get_level(const isyntax_image_t* image, 
 int32_t                libisyntax_level_get_scale(const isyntax_level_t* level);
 int32_t                libisyntax_level_get_width_in_tiles(const isyntax_level_t* level);
 int32_t                libisyntax_level_get_height_in_tiles(const isyntax_level_t* level);
+int32_t                libisyntax_level_get_width(const isyntax_level_t* level);
+int32_t                libisyntax_level_get_height(const isyntax_level_t* level);
+float                  libisyntax_level_get_mpp_x(const isyntax_level_t* level);
+float                  libisyntax_level_get_mpp_y(const isyntax_level_t* level);
 
 //== Cache API ==
 isyntax_error_t libisyntax_cache_create(const char* debug_name_or_null, int32_t cache_size,


### PR DESCRIPTION
This commit:
- Changes offset_in_pixels to u64. In my tests this also corresponds to the actual size of the padding
- Add offset also for level = 0
- Add width and height properties to the level
- Expose the height, width, mpp_x and mpp_y of each level in the public API.

It is forked from the changes I made to make a read_region function work.