### PR TITLE
Unit testing: test for BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,42 +60,40 @@ endif()
 #   to src/CMakeLists to avoid circular deps.
 
 # Note: checking if running in test mode to avoid downloading a large test file for regular builds.
-# TODO(avirodov): doesn't actually work. For now downloading test files even if just want to build.
-#option(BUILD_TESTING "" OFF)
-include(CTest)
-# message(BUILD_TESTING="${BUILD_TESTING}")
-# if(BUILD_TESTING)
+option(BUILD_TESTING "Build tests" OFF)
+message(STATUS "BUILD_TESTING = ${BUILD_TESTING}")
+if(BUILD_TESTING)
+    include(CTest)
+    add_test(NAME smoke_example_runs_no_args
+            COMMAND isyntax_example)
 
-add_test(NAME smoke_example_runs_no_args
-        COMMAND isyntax_example)
+    # Thank you https://gitlab.com/BioimageInformaticsGroup/openphi
+    if (NOT EXISTS ${CMAKE_BINARY_DIR}/testslide.isyntax)
+        file(DOWNLOAD https://zenodo.org/record/5037046/files/testslide.isyntax?download=1 ${CMAKE_BINARY_DIR}/testslide.isyntax SHOW_PROGRESS)
+    endif()
 
-# Thank you https://gitlab.com/BioimageInformaticsGroup/openphi
-if (NOT EXISTS ${CMAKE_BINARY_DIR}/testslide.isyntax)
-    file(DOWNLOAD https://zenodo.org/record/5037046/files/testslide.isyntax?download=1 ${CMAKE_BINARY_DIR}/testslide.isyntax SHOW_PROGRESS)
-endif()
+    # Test that we can show levels and that number of tiles shown is as expected for this test tile.
+    add_test(NAME smoke_example_runs_with_test_slide_showing_levels
+            COMMAND isyntax_example ${CMAKE_BINARY_DIR}/testslide.isyntax)
+    set_tests_properties(smoke_example_runs_with_test_slide_showing_levels
+            PROPERTIES PASS_REGULAR_EXPRESSION "width.*=256")
+    set_tests_properties(smoke_example_runs_with_test_slide_showing_levels
+            PROPERTIES PASS_REGULAR_EXPRESSION "height.*=384")
 
-# Test that we can show levels and that number of tiles shown is as expected for this test tile.
-add_test(NAME smoke_example_runs_with_test_slide_showing_levels
-        COMMAND isyntax_example ${CMAKE_BINARY_DIR}/testslide.isyntax)
-set_tests_properties(smoke_example_runs_with_test_slide_showing_levels
-        PROPERTIES PASS_REGULAR_EXPRESSION "width.*=256")
-set_tests_properties(smoke_example_runs_with_test_slide_showing_levels
-        PROPERTIES PASS_REGULAR_EXPRESSION "height.*=384")
+    # Test that we can produce a tile png.
+    add_test(NAME smoke_example_runs_with_test_slide_producing_output
+            COMMAND isyntax_example ${CMAKE_BINARY_DIR}/testslide.isyntax 3 5 10 ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
 
-# Test that we can produce a tile png.
-add_test(NAME smoke_example_runs_with_test_slide_producing_output
-        COMMAND isyntax_example ${CMAKE_BINARY_DIR}/testslide.isyntax 3 5 10 ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
+    # Test that the tile png was indeed produced.
+    add_test(NAME smoke_example_runs_with_test_slide_produced_output
+            COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
+    set_tests_properties(smoke_example_runs_with_test_slide_produced_output PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
 
-# Test that the tile png was indeed produced.
-add_test(NAME smoke_example_runs_with_test_slide_produced_output
-        COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
-set_tests_properties(smoke_example_runs_with_test_slide_produced_output PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
+    # Regression test that the produced tile pixels did not change from expected.
+    add_test(NAME regression_example_tile_3_5_10_pixel_check
+            COMMAND ${CMAKE_COMMAND} -E compare_files ../test/expected_output/testslide_example_tile_3_5_10.png ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
+    set_tests_properties(regression_example_tile_3_5_10_pixel_check PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
 
-# Regression test that the produced tile pixels did not change from expected.
-add_test(NAME regression_example_tile_3_5_10_pixel_check
-        COMMAND ${CMAKE_COMMAND} -E compare_files ../test/expected_output/testslide_example_tile_3_5_10.png ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
-set_tests_properties(regression_example_tile_3_5_10_pixel_check PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
-
-# endif()  # if(BUILD_TESTING)
+endif() # if(BUILD_TESTING)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,15 @@ if(BUILD_TESTING)
             COMMAND isyntax_example)
 
     # Thank you https://gitlab.com/BioimageInformaticsGroup/openphi
-    if (NOT EXISTS ${CMAKE_BINARY_DIR}/testslide.isyntax)
-        file(DOWNLOAD https://zenodo.org/record/5037046/files/testslide.isyntax?download=1 ${CMAKE_BINARY_DIR}/testslide.isyntax SHOW_PROGRESS)
+    if (NOT EXISTS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testslide.isyntax)
+        file(DOWNLOAD https://zenodo.org/record/5037046/files/testslide.isyntax?download=1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testslide.isyntax SHOW_PROGRESS)
+    else()
+        message(STATUS "Found test slide (no need to download): ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testslide.isyntax")
     endif()
 
     # Test that we can show levels and that number of tiles shown is as expected for this test tile.
     add_test(NAME smoke_example_runs_with_test_slide_showing_levels
-            COMMAND isyntax_example ${CMAKE_BINARY_DIR}/testslide.isyntax)
+            COMMAND isyntax_example ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testslide.isyntax)
     set_tests_properties(smoke_example_runs_with_test_slide_showing_levels
             PROPERTIES PASS_REGULAR_EXPRESSION "width.*=256")
     set_tests_properties(smoke_example_runs_with_test_slide_showing_levels
@@ -82,16 +84,16 @@ if(BUILD_TESTING)
 
     # Test that we can produce a tile png.
     add_test(NAME smoke_example_runs_with_test_slide_producing_output
-            COMMAND isyntax_example ${CMAKE_BINARY_DIR}/testslide.isyntax 3 5 10 ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
+            COMMAND isyntax_example ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/testslide.isyntax 3 5 10 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/output_smoke_example_runs_with_test_slide_producing_output.png)
 
     # Test that the tile png was indeed produced.
     add_test(NAME smoke_example_runs_with_test_slide_produced_output
-            COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
+            COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/output_smoke_example_runs_with_test_slide_producing_output.png)
     set_tests_properties(smoke_example_runs_with_test_slide_produced_output PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
 
     # Regression test that the produced tile pixels did not change from expected.
     add_test(NAME regression_example_tile_3_5_10_pixel_check
-            COMMAND ${CMAKE_COMMAND} -E compare_files ../test/expected_output/testslide_example_tile_3_5_10.png ${CMAKE_BINARY_DIR}/output_smoke_example_runs_with_test_slide_producing_output.png)
+            COMMAND ${CMAKE_COMMAND} -E compare_files ../test/expected_output/testslide_example_tile_3_5_10.png ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/output_smoke_example_runs_with_test_slide_producing_output.png)
     set_tests_properties(regression_example_tile_3_5_10_pixel_check PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
 
 endif() # if(BUILD_TESTING)


### PR DESCRIPTION
This is a fork of #12, with a fix that prevents the test slide from being downloaded if BUILD_TESTING is not set to ON. 
(To enable testing, pass -DBUILD_TESTING=ON to CMake)

I also added a status message that reports if the test slide is already present, and changed the location of the test file so that it doesn't have to be redownloaded if the CMake configuration changes (e.g., if you have separate Debug and Release configs).