### PR TITLE
Global mutex with atomics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,17 +79,16 @@ add_library(libisyntax
         ${LIBISYNTAX_COMMON_SOURCE_FILES}
 )
 
-add_executable(isyntax_example
-        src/isyntax_example.c
-        ${LIBISYNTAX_COMMON_SOURCE_FILES}
-)
-
 if (WIN32)
     target_link_libraries(libisyntax winmm)
-    target_link_libraries(isyntax_example winmm)
 else()
-
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(libisyntax Threads::Threads)
 endif()
+
+add_executable(isyntax_example src/isyntax_example.c)
+target_link_libraries(isyntax_example libisyntax)
 
 # TODO(avirodov): Consider moving testing to its own test/CMakeLists. This will require moving the library building
 #   to src/CMakeLists to avoid circular deps.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,6 @@ add_library(libisyntax
 if (WIN32)
     target_link_libraries(libisyntax winmm)
 else()
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads REQUIRED)
-    target_link_libraries(libisyntax Threads::Threads)
 endif()
 
 add_executable(isyntax_example src/isyntax_example.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,11 @@ if(BUILD_TESTING)
             COMMAND ${CMAKE_COMMAND} -E compare_files ../test/expected_output/testslide_example_tile_3_5_10.png ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/output_smoke_example_runs_with_test_slide_producing_output.png)
     set_tests_properties(regression_example_tile_3_5_10_pixel_check PROPERTIES DEPENDS smoke_example_runs_with_test_slide_producing_output)
 
+    add_executable(thread_test test/thread_test.c)
+    target_link_libraries(thread_test libisyntax)
+    add_test(NAME smoke_thread_test
+            COMMAND thread_test)
+
 endif() # if(BUILD_TESTING)
 
 

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -71,11 +71,11 @@ _Noreturn DWORD WINAPI thread_proc(void* parameter) {
 			Sleep(100);
 			continue;
 		}
-		if (!is_queue_work_in_progress(thread_info->queue)) {
+		if (!work_queue_is_work_in_progress(thread_info->queue)) {
 			Sleep(1);
 			WaitForSingleObjectEx(thread_info->queue->semaphore, 1, FALSE);
 		}
-		do_worker_work(thread_info->queue, thread_info->logical_thread_index);
+        work_queue_do_work(thread_info->queue, thread_info->logical_thread_index);
 	}
 }
 
@@ -86,8 +86,8 @@ static void init_thread_pool() {
 	global_worker_thread_count = total_thread_count - 1;
 	global_active_worker_thread_count = global_worker_thread_count;
 
-	global_work_queue = create_work_queue("/worksem", 1024); // Queue for newly submitted tasks
-	global_completion_queue = create_work_queue("/completionsem", 1024); // Message queue for completed tasks
+	global_work_queue = work_queue_create("/worksem", 1024); // Queue for newly submitted tasks
+	global_completion_queue = work_queue_create("/completionsem", 1024); // Message queue for completed tasks
 
 	// NOTE: the main thread is considered thread 0.
 	for (i32 i = 1; i < total_thread_count; ++i) {

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -174,47 +174,45 @@ atomic_int dbgctr_init_thread_pool_counter = 0;
 atomic_int dbgctr_init_global_mutexes_created = 0;
 
 static benaphore_t* libisyntax_get_global_mutex() {
-  // https://stackoverflow.com/questions/42082219/declaring-atomic-pointers-vs-pointers-to-atomics
-  static benaphore_t* _Atomic libisyntax_global_mutex = NULL;
+    // https://stackoverflow.com/questions/42082219/declaring-atomic-pointers-vs-pointers-to-atomics
+    static benaphore_t libisyntax_global_mutex;
+    static atomic_int init_status = 0; // 0 - not initialized, 1 - being initialized, 2 - done initializing.
 
-  // We need to establish a global mutex, and this is nontrivial as mutex primitives available don't allow static
-  // initialization (more discussion in https://github.com/amspath/libisyntax/issues/16).
-  // Because we can't wait on an atomic, we will create the mutex on every parallel call, but only one mutex will be
-  // used eventually by all threads. Since this is first used in libisyntax_init(), assuming contention is low and
-  // number of extra mutexes created will be low as well.
-  benaphore_t* libisyntax_mutex = atomic_load(&libisyntax_global_mutex);
-  if (libisyntax_mutex == NULL) {
-    libisyntax_mutex = malloc(sizeof(benaphore_t));
-    *libisyntax_mutex = benaphore_create();
-    DBGCTR_COUNT(dbgctr_init_global_mutexes_created);
-    benaphore_t* expected = NULL;
-    if (atomic_compare_exchange_strong(&libisyntax_global_mutex, &expected, libisyntax_mutex)) {
-      // This thread's mutex wins, keep using it.
+    // We need to establish a global mutex, and this is nontrivial as mutex primitives available don't allow static
+    // initialization (more discussion in https://github.com/amspath/libisyntax/issues/16).
+    int init_status_expected = 0;
+    if (atomic_compare_exchange_strong(&init_status, &init_status_expected, 1)) {
+        // We get to do the initialization
+        libisyntax_global_mutex = benaphore_create();
+        DBGCTR_COUNT(dbgctr_init_global_mutexes_created);
+        atomic_store(&init_status, 2);
+    } else if (init_status_expected == 2) {
+        // Initialization done.
     } else {
-      // This thread's mutex lost, clean up and load the winning mutex from the other thread.
-      benaphore_destroy(libisyntax_mutex);
-      free(libisyntax_mutex);
-      libisyntax_mutex = atomic_load(&libisyntax_global_mutex);
+        // Wait until the other thread finishes initialization. Since we don't have a mutex, spinlock is
+        // the best we can do here. It should be a very short critical section.
+        while (atomic_load(&init_status) < 2) {
+            // spin.
+        }
     }
-  };
 
-  return libisyntax_mutex;
+    return &libisyntax_global_mutex;
 }
 
 isyntax_error_t libisyntax_init() {
-  // Lock-unlock to ensure that all parallel calls to libisyntax_init() wait for the actual initialization to complete.
-  benaphore_lock(libisyntax_get_global_mutex());
-  static bool libisyntax_global_init_complete = false;
+    // Lock-unlock to ensure that all parallel calls to libisyntax_init() wait for the actual initialization to complete.
+    benaphore_lock(libisyntax_get_global_mutex());
+    static bool libisyntax_global_init_complete = false;
 
-  if (libisyntax_global_init_complete == false) {
-    // Actual initialization.
-    get_system_info(false);
-    DBGCTR_COUNT(dbgctr_init_thread_pool_counter);
-    init_thread_pool();
-    libisyntax_global_init_complete = true;
-  }
-  benaphore_unlock(libisyntax_get_global_mutex());
-  return LIBISYNTAX_OK;
+    if (libisyntax_global_init_complete == false) {
+        // Actual initialization.
+        get_system_info(false);
+        DBGCTR_COUNT(dbgctr_init_thread_pool_counter);
+        init_thread_pool();
+        libisyntax_global_init_complete = true;
+    }
+    benaphore_unlock(libisyntax_get_global_mutex());
+    return LIBISYNTAX_OK;
 }
 
 isyntax_error_t libisyntax_open(const char* filename, int32_t is_init_allocators, isyntax_t** out_isyntax) {

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -106,7 +106,6 @@ static void init_thread_pool() {
 #else
 
 #include <pthread.h>
-#include <stdatomic.h>
 
 static void* worker_thread(void* parameter) {
     platform_thread_info_t* thread_info = (platform_thread_info_t*) parameter;

--- a/test/thread_test.c
+++ b/test/thread_test.c
@@ -1,0 +1,91 @@
+#include <threads.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include "libisyntax.h"
+
+typedef struct test_thread_t {
+  thrd_t thread_id;
+  atomic_int* atomic_sync_flag; // Spinlock to sync threads.
+  bool force_sync;
+
+  // TODO(avirodov): implement if needed. Or we can keep making sure that test output comes after test work.
+  // char* output_buffer; // Avoid console output due to it may be implemented with a mutex or other sync.
+  // int output_buffer_len;
+  // int output_buffer_capacity;
+
+  void* arg;
+  int (*func)(void*);
+  int result;
+} test_thread_t;
+
+int test_print(void* arg) {
+  clock_t current_clock = clock();
+  printf("test_print tid=%ld currect_clock=%ld\n", thrd_current(), current_clock);
+  return 0;
+}
+
+int parallel_sync_and_call(void* arg) {
+  test_thread_t* test_thread = (test_thread_t*)arg;
+  // Wait in spinlock.
+  while (test_thread->force_sync && atomic_load(&test_thread->atomic_sync_flag) == 0) {
+    // noop.
+  }
+
+  // Run test code.
+  return test_thread->func(test_thread->arg);
+}
+
+void parallel_run(int (*func)(void*), void* arg, bool force_sync) {
+#define n_threads 10
+  const int n_iterations = 2;
+
+  for (int iter = 0; iter < n_iterations; ++iter) {
+    printf("== parallel run iter %d ==\n", iter);
+    atomic_int atomic_sync_flag = 0;
+    test_thread_t threads[n_threads] = {0};
+
+    // Spawn the threads.
+    for (int thread_i = 0; thread_i < n_threads; ++thread_i) {
+
+      threads[thread_i].atomic_sync_flag = &atomic_sync_flag;
+      threads[thread_i].func = func;
+      threads[thread_i].arg = arg;
+      threads[thread_i].force_sync = force_sync;
+
+      assert(thrd_create(&threads[thread_i].thread_id, parallel_sync_and_call, &threads[thread_i]) == thrd_success);
+    }
+
+    // Sync and start the threads.
+    const int milliseconds_to_nanoseconds = 1000 * 1000;
+    thrd_sleep(&(struct timespec){.tv_nsec=10 * milliseconds_to_nanoseconds}, NULL);
+    atomic_store(&atomic_sync_flag, 1);
+
+    // Join the threads.
+    for (int thread_i = 0; thread_i < n_threads; ++thread_i) {
+      thrd_join(threads[thread_i].thread_id, &threads[thread_i].result);
+    }
+  }
+}
+
+extern atomic_int dbgctr_init_thread_pool_counter;
+extern atomic_int dbgctr_init_global_mutexes_created;
+
+int test_libisyntax_init(void* arg) {
+  clock_t current_clock = clock();
+  isyntax_error_t result = libisyntax_init();
+  printf("test_print tid=%ld currect_clock=%ld result=%d init_counter=%d mutexes_created_counter=%d\n",
+         thrd_current(), current_clock, result,
+         atomic_load(&dbgctr_init_thread_pool_counter),
+         atomic_load(&dbgctr_init_global_mutexes_created));
+  return (int)result;
+}
+
+int main() {
+  parallel_run(test_print, NULL, /*force_sync=*/true);
+  parallel_run(test_libisyntax_init, NULL, /*force_sync=*/true);
+  return 0;
+}

--- a/test/thread_test.c
+++ b/test/thread_test.c
@@ -1,3 +1,14 @@
+#include "common.h"
+
+#if WINDOWS
+// TODO(avirodov): enable this test after we figured out cross-platform threading.
+//   More discussion in https://github.com/amspath/libisyntax/issues/16
+int main(void) {
+    printf("Test disabled on windows.");
+    return 0;
+}
+#else
+
 #include <threads.h>
 #include <stdio.h>
 #include <assert.h>
@@ -89,3 +100,5 @@ int main() {
   parallel_run(test_libisyntax_init, NULL, /*force_sync=*/true);
   return 0;
 }
+
+#endif

--- a/test/thread_test.c
+++ b/test/thread_test.c
@@ -67,7 +67,8 @@ void parallel_run(int (*func)(void*), void* arg, bool force_sync) {
       threads[thread_i].arg = arg;
       threads[thread_i].force_sync = force_sync;
 
-      assert(thrd_create(&threads[thread_i].thread_id, parallel_sync_and_call, &threads[thread_i]) == thrd_success);
+      int result = thrd_create(&threads[thread_i].thread_id, parallel_sync_and_call, &threads[thread_i]);
+      assert(result == thrd_success);
     }
 
     // Sync and start the threads.


### PR DESCRIPTION
This is a solution to #16. See comments in `libisyntax_get_global_mutex()` for further implementation details.