### PR TITLE
Add routines for reading label and macro images

### DIFF
--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -195,6 +195,86 @@ static i32 parse_up_to_five_integers(const char* str, i32* array_of_five_integer
 	return 5;
 }
 
+static void bgra_to_rgba(uint32_t *pixels, int width, int height) {
+    int num_pixels = width * height;
+    int num_pixels_aligned = (num_pixels / 4) * 4;
+
+#if defined(__ARM_NEON)
+    for (int i = 0; i < num_pixels_aligned; i += 4) {
+        uint32x4_t bgra = vld1q_u32(pixels + i);
+        uint32x4_t b_mask = vdupq_n_u32(0x000000FF);
+        uint32x4_t r_mask = vdupq_n_u32(0x00FF0000);
+        uint32x4_t b = vandq_u32(bgra, b_mask);
+        uint32x4_t r = vandq_u32(bgra, r_mask);
+        uint32x4_t br_swapped = vorrq_u32(vshlq_n_u32(b, 16), vshrq_n_u32(r, 16));
+        uint32x4_t ga_alpha_mask = vdupq_n_u32(0xFF00FF00);
+        uint32x4_t ga_alpha = vandq_u32(bgra, ga_alpha_mask);
+        uint32x4_t rgba = vorrq_u32(ga_alpha, br_swapped);
+        vst1q_u32(pixels + i, rgba);
+    }
+#elif defined(__SSE2__)
+    for (int i = 0; i < num_pixels_aligned; i += 4) {
+        __m128i bgra = _mm_loadu_si128((__m128i*)(pixels + i));
+        __m128i b_mask = _mm_set1_epi32(0x000000FF);
+        __m128i r_mask = _mm_set1_epi32(0x00FF0000);
+        __m128i b = _mm_and_si128(bgra, b_mask);
+        __m128i r = _mm_and_si128(bgra, r_mask);
+        __m128i br_swapped = _mm_or_si128(_mm_slli_epi32(b, 16), _mm_srli_epi32(r, 16));
+        __m128i ga_alpha_mask = _mm_set1_epi32(0xFF00FF00);
+        __m128i ga_alpha = _mm_and_si128(bgra, ga_alpha_mask);
+        __m128i rgba = _mm_or_si128(ga_alpha, br_swapped);
+        _mm_storeu_si128((__m128i*)(pixels + i), rgba);
+    }
+#else
+    for (int i = num_pixels_aligned; i < num_pixels; ++i) {
+        uint32_t val = pixels[i];
+        pixels[i] = ((val & 0xff) << 16) | (val & 0x00ff00) | ((val & 0xff0000) >> 16) | (val & 0xff000000);
+    }
+#endif
+}
+
+static u8* isyntax_decode_jpeg_stream(u8* compressed, size_t compressed_len, i32* width, i32* height, i32* channels_in_file,
+                                      enum isyntax_pixel_format_t pixel_format) {
+    u8* pixels = NULL;
+    i32 w = 0;
+    i32 h = 0;
+
+#ifdef ISYNTAX_JPEG_DECODER_USE_LIBJPEG
+    // TODO: Why does this crash?
+    // Apparently, there is a bug in the libjpeg-turbo implementation of jsimd_can_h2v2_fancy_upsample() when using SIMD.
+    // jsimd_h2v2_fancy_upsample_avx2 writes memory out of bounds.
+    // This causes the program to crash eventually when trying to free memory in free_pool().
+    // When using a hardware watchpoint on the corrupted memory, the overwiting occurs in x86_64/jdsample-avx2.asm at line 358:
+    //     vmovdqu     YMMWORD [rdi+3*SIZEOF_YMMWORD], ymm6
+    // WORKAROUND: disabled SIMD in jsimd_can_h2v2_fancy_upsample().
+
+    pixels = jpeg_decode_image(compressed, compressed_len, &w, &h, channels_in_file);
+    if (pixel_format == LIBISYNTAX_PIXEL_FORMAT_BGRA) {
+        DUMMY_STATEMENT; // no action needed
+    } else if (pixel_format == LIBISYNTAX_PIXEL_FORMAT_RGBA) {
+        bgra_to_rgba((uint32_t*)pixels, w, h);
+    }
+#else
+    // stb_image.h
+    pixels = stbi_load_from_memory(compressed, (int)compressed_len, &w, &h, channels_in_file, 4);
+    if (pixel_format == LIBISYNTAX_PIXEL_FORMAT_RGBA) {
+        DUMMY_STATEMENT; // no action needed
+    } else if (pixel_format == LIBISYNTAX_PIXEL_FORMAT_BGRA) {
+        bgra_to_rgba((uint32_t*)pixels, w, h);
+    }
+#endif
+    if (width) *width = w;
+    if (height) *height = h;
+    return pixels;
+}
+
+u8* isyntax_get_associated_image_pixels(isyntax_image_t* image, enum isyntax_pixel_format_t pixel_format) {
+    i32 channels_in_file = 0;
+    return isyntax_decode_jpeg_stream(image->jpeg_compressed_pixels,
+                                      image->jpeg_compressed_len, &image->width, &image->height,
+                                      &channels_in_file, pixel_format);
+}
+
 static void isyntax_parse_ufsimport_child_node(isyntax_t* isyntax, u32 group, u32 element, char* value, u64 value_len) {
 
 	switch(group) {
@@ -317,29 +397,12 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 				case 0x1005: { /*PIM_DP_IMAGE_DATA*/
 					size_t decoded_capacity = value_len;
 					size_t decoded_len = 0;
-					i32 last_char = value[value_len-1];
+					char last_char = value[value_len-1];
 					if (last_char == '/') {
 						value_len--; // The last character may cause the base64 decoding to fail if invalid
 					}
-					u8* decoded = base64_decode((u8*)value, value_len, &decoded_len);
-					if (decoded) {
-						i32 channels_in_file = 0;
-#ifdef ISYNTAX_JPEG_DECODER_USE_LIBJPEG
-						// TODO: Why does this crash?
-						// Apparently, there is a bug in the libjpeg-turbo implementation of jsimd_can_h2v2_fancy_upsample() when using SIMD.
-						// jsimd_h2v2_fancy_upsample_avx2 writes memory out of bounds.
-						// This causes the program to crash eventually when trying to free memory in free_pool().
-						// When using a hardware watchpoint on the corrupted memory, the overwiting occurs in x86_64/jdsample-avx2.asm at line 358:
-						//     vmovdqu     YMMWORD [rdi+3*SIZEOF_YMMWORD], ymm6
-						// WORKAROUND: disabled SIMD in jsimd_can_h2v2_fancy_upsample().
-
-						image->pixels = jpeg_decode_image(decoded, decoded_len, &image->width, &image->height, &channels_in_file);
-#else
-						// stb_image.h
-						image->pixels = stbi_load_from_memory(decoded, decoded_len, &image->width, &image->height, &channels_in_file, 4);
-#endif
-						free(decoded);
-					}
+					image->jpeg_compressed_pixels = base64_decode((u8*)value, value_len, &decoded_len);
+                    image->jpeg_compressed_len = decoded_len;
 				} break;
 				case 0x1013: /*DP_COLOR_MANAGEMENT*/                        {} break;
 				case 0x1014: /*DP_IMAGE_POST_PROCESSING*/                   {} break;
@@ -981,7 +1044,7 @@ bool isyntax_parse_xml_header(isyntax_t* isyntax, char* xml_header, i64 chunk_le
 						// Leaf node WITHOUT children.
 						// In this case we didn't already parse the attributes at the YXML_ATTREND stage.
 						// Now at the YXML_ELEMEND stage we can parse the complete tag at once (attributes + content).
-						console_print_verbose("%sDICOM: %-40s (0x%04x, 0x%04x), size:%-8u = %s\n", get_spaces(parser->node_stack_index),
+						console_print_verbose("%sDICOM: %-40s (0x%04x, 0x%04x), size:%-8zu = %s\n", get_spaces(parser->node_stack_index),
 						                      parser->current_dicom_attribute_name,
 						                      parser->current_dicom_group_tag, parser->current_dicom_element_tag,
 											  parser->contentlen, parser->contentbuf);
@@ -1345,10 +1408,9 @@ static rgba_t ycocg_to_bgr(i32 Y, i32 Co, i32 Cg) {
 }
 
 static void convert_ycocg_to_bgra_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_bgra) {
-	i32 first_valid_pixel = ISYNTAX_IDWT_FIRST_VALID_PIXEL;
     i32 aligned_width = (width / 8) * 8;
 
-	for (i32 y = 0; y < aligned_width; ++y) {
+	for (i32 y = 0; y < height; ++y) {
 		u32* dest = out_bgra + (y * width);
         i32 i = 0;
 #if defined(__SSE2__) && defined(__SSSE3__)
@@ -1416,10 +1478,9 @@ static void convert_ycocg_to_bgra_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg,
 }
 
 static void convert_ycocg_to_rgba_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_rgba) {
-    i32 first_valid_pixel = ISYNTAX_IDWT_FIRST_VALID_PIXEL;
     i32 aligned_width = (width / 8) * 8;
 
-    for (i32 y = 0; y < aligned_width; ++y) {
+    for (i32 y = 0; y < height; ++y) {
         u32* dest = out_rgba + (y * width);
         i32 i = 0;
 #if defined(__SSE2__) && defined(__SSSE3__)
@@ -1442,7 +1503,6 @@ static void convert_ycocg_to_rgba_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg,
 
 			__m128i A = _mm_setr_epi32(0, 0, 0xffffffff, 0xffffffff); // ----AAAA
 
-			// Shuffle into the right order -> BGRA
 			// Shuffle into the right order -> RGBA
 			__m128i RG = _mm_or_si128(R, G);
 			__m128i BA = _mm_or_si128(B, A);
@@ -2281,7 +2341,7 @@ bool isyntax_hulsken_decompress(u8* compressed, size_t compressed_size, i32 bloc
 		do {
 			if (bits_read >= block_size_in_bits) {
 //				dump_block(compressed, compressed_size);
-				console_print_error("Error: isyntax_hulsken_decompress(): invalid codeblock, Huffman table extends out of bounds (compressed_size=%d)\n", compressed_size);
+				console_print_error("Error: isyntax_hulsken_decompress(): invalid codeblock, Huffman table extends out of bounds (compressed_size=%zu)\n", compressed_size);
 				ASSERT(!"out of bounds");
 				memset(out_buffer, 0, coeff_buffer_size);
 				release_temp_memory(&temp_memory);
@@ -2490,7 +2550,7 @@ bool isyntax_hulsken_decompress(u8* compressed, size_t compressed_size, i32 bloc
 
 	if (serialized_length != decompressed_length) {
 //		dump_block(compressed, compressed_size);
-		console_print("iSyntax: decompressed size mismatch (size=%d): expected %lld observed %d\n",
+		console_print("iSyntax: decompressed size mismatch (size=%zu): expected %lld observed %d\n",
 				 compressed_size, serialized_length, decompressed_length);
 		ASSERT(!"size mismatch");
 	}
@@ -3227,6 +3287,8 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, bool init_allocators
 }
 
 void isyntax_destroy(isyntax_t* isyntax) {
+    // TODO(pvalkema): review synchronization needed to safely destroy the isyntax_t
+    // NOTE: in isyntax_streamer.c, the refcount can be incremented in various places (while threaded jobs are running)
 	while (isyntax->refcount > 0) {
 		platform_sleep(1);
 		if (isyntax->work_submission_queue) {
@@ -3257,10 +3319,10 @@ void isyntax_destroy(isyntax_t* isyntax) {
 	}
 	for (i32 image_index = 0; image_index < isyntax->image_count; ++image_index) {
 		isyntax_image_t* image = isyntax->images + image_index;
-		if (image->pixels) {
-			free(image->pixels);
-			image->pixels = NULL;
-		}
+        if (image->jpeg_compressed_pixels) {
+            free(image->jpeg_compressed_pixels);
+            image->jpeg_compressed_pixels = NULL;
+        }
 		if (image->image_type == ISYNTAX_IMAGE_TYPE_WSI) {
 			if (image->codeblocks) {
 				free(image->codeblocks);

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -292,7 +292,8 @@ typedef struct isyntax_level_t {
 
 typedef struct isyntax_image_t {
 	u32 image_type;
-	u8* pixels;
+    u8* jpeg_compressed_pixels;
+    size_t jpeg_compressed_len;
 	i32 width;
 	i32 height;
 	i32 width_minus_padding;
@@ -403,6 +404,7 @@ u32 isyntax_get_adjacent_tiles_mask_only_existing(isyntax_level_t* level, i32 ti
 u32 isyntax_idwt_tile_for_color_channel(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y, i32 color, icoeff_t* dest_buffer);
 void isyntax_decompress_codeblock_in_chunk(isyntax_codeblock_t* codeblock, i32 block_width, i32 block_height, u8* chunk, u64 chunk_base_offset, i32 compressor_version, i16* out_buffer);
 i32 isyntax_get_chunk_codeblocks_per_color_for_level(i32 level, bool has_ll);
+u8* isyntax_get_associated_image_pixels(isyntax_image_t* image, enum isyntax_pixel_format_t pixel_format);
 
 
 #ifdef __cplusplus

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -84,3 +84,8 @@ isyntax_error_t libisyntax_read_region(isyntax_t* isyntax, isyntax_cache_t* isyn
                                        int32_t pixel_format);
 
 
+isyntax_error_t libisyntax_read_label_image(isyntax_t* isyntax, int32_t* width, int32_t* height,
+                                                   uint32_t** pixels_buffer, int32_t pixel_format);
+isyntax_error_t libisyntax_read_macro_image(isyntax_t* isyntax, int32_t* width, int32_t* height,
+                                                   uint32_t** pixels_buffer, int32_t pixel_format);
+


### PR DESCRIPTION
Plus minor code cleanup.

Could you review this, @alex-virodov?

Example code using the proposed API to extract macro and label images:
```C
int32_t macro_width = 0;
int32_t macro_height = 0;
uint32_t* macro_pixels = NULL;
CHECK_LIBISYNTAX_OK(libisyntax_read_macro_image(isyntax, &macro_width, &macro_height, &macro_pixels,
                                                LIBISYNTAX_PIXEL_FORMAT_RGBA));
if (macro_pixels) {
    stbi_write_png("macro.png", macro_width, macro_height, 4, macro_pixels, macro_width * 4);
}
```