### PR TITLE
[NOT FOR MERGE YET] Cache under api try2

### DIFF
--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -1977,7 +1977,6 @@ u32 isyntax_idwt_tile_for_color_channel(isyntax_t* isyntax, isyntax_image_t* wsi
 }
 
 void isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y,
-                       block_allocator_t* ll_coeff_block_allocator,
                        u32* out_buffer_or_null, enum isyntax_pixel_format_t pixel_format) {
 	// printf("@@@ isyntax_load_tile scale=%d tile_x=%d tile_y=%d\n", scale, tile_x, tile_y);
 	isyntax_level_t* level = wsi->levels + scale;
@@ -2036,25 +2035,25 @@ void isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 
 
 		// TODO(avirodov): instead of releasing here, skip copy if still allocated.
 		if (child_top_left->color_channels[color].coeff_ll) {
-			block_free(ll_coeff_block_allocator, child_top_left->color_channels[color].coeff_ll);
+			block_free(isyntax->ll_coeff_block_allocator, child_top_left->color_channels[color].coeff_ll);
 		}
 		if (child_top_right->color_channels[color].coeff_ll) {
-			block_free(ll_coeff_block_allocator, child_top_right->color_channels[color].coeff_ll);
+			block_free(isyntax->ll_coeff_block_allocator, child_top_right->color_channels[color].coeff_ll);
 		}
 		if (child_bottom_left->color_channels[color].coeff_ll) {
-			block_free(ll_coeff_block_allocator, child_bottom_left->color_channels[color].coeff_ll);
+			block_free(isyntax->ll_coeff_block_allocator, child_bottom_left->color_channels[color].coeff_ll);
 		}
 		if (child_bottom_right->color_channels[color].coeff_ll) {
-			block_free(ll_coeff_block_allocator, child_bottom_right->color_channels[color].coeff_ll);
+			block_free(isyntax->ll_coeff_block_allocator, child_bottom_right->color_channels[color].coeff_ll);
 		}
 
 		// NOTE: malloc() and free() can become a bottleneck, they don't scale well especially across many threads.
 		// We use a custom block allocator to address this.
 		i64 start_malloc = get_clock();
-		child_top_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
-		child_top_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
-		child_bottom_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
-		child_bottom_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(ll_coeff_block_allocator);
+		child_top_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(isyntax->ll_coeff_block_allocator);
+		child_top_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(isyntax->ll_coeff_block_allocator);
+		child_bottom_left->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(isyntax->ll_coeff_block_allocator);
+		child_bottom_right->color_channels[color].coeff_ll = (icoeff_t*)block_alloc(isyntax->ll_coeff_block_allocator);
 		elapsed_malloc += get_seconds_elapsed(start_malloc, get_clock());
 		i32 dest_stride = block_width;
 		// Blit top left child LL block

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -397,8 +397,7 @@ void isyntax_set_work_queue(isyntax_t* isyntax, work_queue_t* work_queue);
 bool isyntax_open(isyntax_t* isyntax, const char* filename, bool init_allocators);
 void isyntax_destroy(isyntax_t* isyntax);
 void isyntax_idwt(icoeff_t* idwt, i32 quadrant_width, i32 quadrant_height, bool output_steps_as_png, const char* png_name);
-void isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y, block_allocator_t* ll_coeff_block_allocator,
-                       u32* out_buffer_or_null, enum isyntax_pixel_format_t pixel_format);
+void isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y, u32* out_buffer_or_null, enum isyntax_pixel_format_t pixel_format);
 u32 isyntax_get_adjacent_tiles_mask(isyntax_level_t* level, i32 tile_x, i32 tile_y);
 u32 isyntax_get_adjacent_tiles_mask_only_existing(isyntax_level_t* level, i32 tile_x, i32 tile_y);
 u32 isyntax_idwt_tile_for_color_channel(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y, i32 color, icoeff_t* dest_buffer);

--- a/src/isyntax/isyntax_reader.c
+++ b/src/isyntax/isyntax_reader.c
@@ -206,7 +206,6 @@ static void isyntax_openslide_idwt(isyntax_cache_t* cache, isyntax_t* isyntax, i
         ASSERT(pixels_buffer != NULL); // Shouldn't be asking for idwt at level 0 if we're not going to use the result for pixels.
         isyntax_load_tile(isyntax, &isyntax->images[isyntax->wsi_image_index],
                                  tile->tile_scale, tile->tile_x, tile->tile_y,
-                                 &cache->ll_coeff_block_allocator,
                                  pixels_buffer, pixel_format);
         return;
     }
@@ -216,7 +215,6 @@ static void isyntax_openslide_idwt(isyntax_cache_t* cache, isyntax_t* isyntax, i
         //  the lls in the tile. Currently need to recompute idwt.
         isyntax_load_tile(isyntax, &isyntax->images[isyntax->wsi_image_index],
                           tile->tile_scale, tile->tile_x, tile->tile_y,
-                          &cache->ll_coeff_block_allocator,
                           pixels_buffer, pixel_format);
         return;
     }
@@ -231,7 +229,6 @@ static void isyntax_openslide_idwt(isyntax_cache_t* cache, isyntax_t* isyntax, i
 
     isyntax_load_tile(isyntax, &isyntax->images[isyntax->wsi_image_index],
                       tile->tile_scale, tile->tile_x, tile->tile_y,
-                      &cache->ll_coeff_block_allocator,
                       /*pixels_buffer=*/NULL, /*pixel_format=*/0);
 }
 

--- a/src/isyntax/isyntax_reader.h
+++ b/src/isyntax/isyntax_reader.h
@@ -28,3 +28,8 @@ void isyntax_tile_read(isyntax_t* isyntax, isyntax_cache_t* cache, int scale, in
 
 void tile_list_init(isyntax_tile_list_t* list, const char* dbg_name);
 void tile_list_remove(isyntax_tile_list_t* list, isyntax_tile_t* tile);
+
+isyntax_cache_t* isyntax_cache_create(const char* debug_name_or_null, int32_t cache_size);
+void isyntax_cache_inject(isyntax_cache_t* isyntax_cache, isyntax_t* isyntax);
+void isyntax_cache_trim(isyntax_cache_t* isyntax_cache, i32 target_size);
+void isyntax_cache_destroy(isyntax_cache_t* isyntax_cache);

--- a/src/isyntax_example.c
+++ b/src/isyntax_example.c
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
     libisyntax_init();
 
     isyntax_t* isyntax;
-    if (libisyntax_open(filename, /*is_init_allocators=*/0, &isyntax) != LIBISYNTAX_OK) {
+    if (libisyntax_open(filename, &isyntax) != LIBISYNTAX_OK) {
         printf("Failed to open %s\n", filename);
         return -1;
     }
@@ -66,13 +66,9 @@ int main(int argc, char** argv) {
         LOG_VAR("%d", tile_width);
         LOG_VAR("%d", tile_height);
 
-        isyntax_cache_t *isyntax_cache = NULL;
-        CHECK_LIBISYNTAX_OK(libisyntax_cache_create("example cache", 2000, &isyntax_cache));
-        CHECK_LIBISYNTAX_OK(libisyntax_cache_inject(isyntax_cache, isyntax));
-
         // RGBA is what stbi expects.
         uint32_t *pixels_rgba = malloc(tile_width * tile_height * 4);
-        CHECK_LIBISYNTAX_OK(libisyntax_tile_read(isyntax, isyntax_cache, level, tile_x, tile_y,
+        CHECK_LIBISYNTAX_OK(libisyntax_tile_read(isyntax, level, tile_x, tile_y,
                                                  pixels_rgba, LIBISYNTAX_PIXEL_FORMAT_RGBA));
 
         printf("Writing %s...\n", output_png);
@@ -80,7 +76,6 @@ int main(int argc, char** argv) {
         printf("Done writing %s.\n", output_png);
 
         free(pixels_rgba);
-        libisyntax_cache_destroy(isyntax_cache);
 
     } else if (argc >= 4) {
 

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -41,7 +41,7 @@ typedef struct isyntax_cache_t isyntax_cache_t;
 //== Common API ==
 // TODO(avirodov): are repeated calls of libisyntax_init() allowed? Currently I believe not.
 isyntax_error_t libisyntax_init();
-isyntax_error_t libisyntax_open(const char* filename, int32_t is_init_allocators, isyntax_t** out_isyntax);
+isyntax_error_t libisyntax_open(const char* filename, isyntax_t** out_isyntax);
 void            libisyntax_close(isyntax_t* isyntax);
 
 //== Getters API ==
@@ -60,26 +60,14 @@ int32_t                libisyntax_level_get_height(const isyntax_level_t* level)
 float                  libisyntax_level_get_mpp_x(const isyntax_level_t* level);
 float                  libisyntax_level_get_mpp_y(const isyntax_level_t* level);
 
-//== Cache API ==
-isyntax_error_t libisyntax_cache_create(const char* debug_name_or_null, int32_t cache_size,
-                                        isyntax_cache_t** out_isyntax_cache);
-// Note: returns LIBISYNTAX_INVALID_ARGUMENT  if isyntax_to_inject was not initialized with is_init_allocators = 0.
-// TODO(avirodov): this function will fail if the isyntax object has different block size than the first isyntax injected.
-//  Block size variation was not observed in practice, and a proper fix may include supporting multiple block sizes
-//  within isyntax_cache_t implementation.
-isyntax_error_t libisyntax_cache_inject(isyntax_cache_t* isyntax_cache, isyntax_t* isyntax);
-void            libisyntax_cache_destroy(isyntax_cache_t* isyntax_cache);
-
-
 //== Tile API ==
 // Reads a tile into a user-supplied buffer. Buffer size should be [tile_width * tile_height * 4], as returned by
 // `libisyntax_get_tile_width()`/`libisyntax_get_tile_height()`. The caller is responsible for managing the buffer
 // allocation/deallocation.
 // pixel_format is one of isyntax_pixel_format_t.
-isyntax_error_t libisyntax_tile_read(isyntax_t* isyntax, isyntax_cache_t* isyntax_cache,
-                                     int32_t level, int64_t tile_x, int64_t tile_y,
+isyntax_error_t libisyntax_tile_read(isyntax_t* isyntax, int32_t level, int64_t tile_x, int64_t tile_y,
                                      uint32_t* pixels_buffer, int32_t pixel_format);
-isyntax_error_t libisyntax_read_region(isyntax_t* isyntax, isyntax_cache_t* isyntax_cache, int32_t level,
+isyntax_error_t libisyntax_read_region(isyntax_t* isyntax, int32_t level,
                                        int64_t x, int64_t y, int64_t width, int64_t height, uint32_t* pixels_buffer,
                                        int32_t pixel_format);
 


### PR DESCRIPTION
@Falcury can you PTAL? If we commit to global-only cache, I can keep it restricted mostly to libisyntax level. If we want per-isyntax cache, I need to be able to put a cache pointer in isyntax_t, and that makes things much more complicated [Edit: not much, see https://github.com/amspath/libisyntax/tree/cache-under-api-try3, very wip]. As I mentioned in (https://github.com/amspath/libisyntax/issues/4#issuecomment-1553518911), I don't see much use for per-isyntax cache, but please let me know if I'm missing something.

And you can still have no cache at all, and per-isyntax allocators if you are skipping the libisyntax layer.

I still need to figure out proper locking, so not ready for merge. Please let me know if this is a bad direction to take.