### PR TITLE
Fix isyntax_to_tiff.c path when libtiff is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if (NOT TIFF_FOUND)
     endif()
 else()
     include_directories(${TIFF_INCLUDE_DIR})
-    add_executable(isyntax-to-tiff src/isyntax_to_tiff.c)
+    add_executable(isyntax-to-tiff src/examples/isyntax_to_tiff.c)
     target_link_libraries(isyntax-to-tiff libisyntax ${TIFF_LIBRARIES})
 endif()
 


### PR DESCRIPTION
I found a minor issue in the cmakelists file where the path to isyntax_to_tiff.c is not correct when `find_package` finds libtiff. This small change fixed the build for me (on an M1 MacBook Air).