### PR TITLE
Support for reading ICC color profiles

### DIFF
--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -313,6 +313,8 @@ typedef struct isyntax_image_t {
 	bool header_codeblocks_are_partial;
 	bool first_load_complete;
 	bool first_load_in_progress;
+	i64 base64_encoded_icc_profile_file_offset;
+	size_t base64_encoded_icc_profile_len;
 } isyntax_image_t;
 
 typedef struct isyntax_parser_node_t {
@@ -406,6 +408,7 @@ void isyntax_decompress_codeblock_in_chunk(isyntax_codeblock_t* codeblock, i32 b
 i32 isyntax_get_chunk_codeblocks_per_color_for_level(i32 level, bool has_ll);
 u8* isyntax_get_associated_image_pixels(isyntax_t* isyntax, isyntax_image_t* image, enum isyntax_pixel_format_t pixel_format);
 u8* isyntax_get_associated_image_jpeg(isyntax_t* isyntax, isyntax_image_t* image, u32* jpeg_size);
+u8* isyntax_get_icc_profile(isyntax_t* isyntax, isyntax_image_t* image, u32* icc_profile_size);
 
 
 #ifdef __cplusplus

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -480,3 +480,15 @@ isyntax_error_t libisyntax_read_macro_image_jpeg(isyntax_t* isyntax, uint8_t** j
     isyntax_image_t* macro_image = isyntax->images + isyntax->macro_image_index;
     return libisyntax_read_assocatiated_image_jpeg(isyntax, macro_image, jpeg_buffer, jpeg_size);
 }
+
+isyntax_error_t libisyntax_read_icc_profile(isyntax_t* isyntax, isyntax_image_t* image, uint8_t** icc_profile_buffer, uint32_t* icc_profile_size) {
+    ASSERT(icc_profile_buffer);
+    ASSERT(icc_profile_size);
+    u8* icc_profile_compressed = isyntax_get_icc_profile(isyntax, image, icc_profile_size);
+    if (icc_profile_compressed) {
+        *icc_profile_buffer = icc_profile_compressed;
+        return LIBISYNTAX_OK;
+    } else {
+        return LIBISYNTAX_FATAL;
+    }
+}

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -90,4 +90,4 @@ isyntax_error_t libisyntax_read_macro_image(isyntax_t* isyntax, int32_t* width, 
                                                    uint32_t** pixels_buffer, int32_t pixel_format);
 isyntax_error_t libisyntax_read_label_image_jpeg(isyntax_t* isyntax, uint8_t** jpeg_buffer, uint32_t* jpeg_size);
 isyntax_error_t libisyntax_read_macro_image_jpeg(isyntax_t* isyntax, uint8_t** jpeg_buffer, uint32_t* jpeg_size);
-
+isyntax_error_t libisyntax_read_icc_profile(isyntax_t* isyntax, isyntax_image_t* image, uint8_t** icc_profile_buffer, uint32_t* icc_profile_size);


### PR DESCRIPTION
This PR adds support for reading the ICC color profiles of images.

See also https://github.com/amspath/libisyntax/issues/19.