### PR TITLE
Add initial Meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,150 @@
+project(
+  'libisyntax', 'c', 'cpp',
+  license : 'BSD-2-Clause',
+  meson_version : '>=0.51.0',
+  default_options : [
+    'buildtype=release',
+    'c_std=gnu11',
+  ],
+)
+
+is_macos = host_machine.system() == 'darwin'
+is_windows = host_machine.system() == 'windows'
+is_apple_silicon = is_macos and host_machine.cpu() in ['arm', 'aarch64']
+
+cc = meson.get_compiler('c')
+add_project_arguments(
+  cc.get_supported_arguments(
+    # there are many of these, and they're sometimes dependent on compile
+    # options
+    '-Wno-unused-function',
+    '-Wno-unused-but-set-variable',
+    '-Wno-unused-variable',
+  ),
+  language : 'c',
+)
+
+tiff = dependency('libtiff-4', required : false)
+if is_windows
+  threads = dependency('', required : false)
+  winmm = cc.find_library('winmm')
+else
+  threads = dependency('threads')
+  winmm = dependency('', required : false)
+endif
+
+if is_apple_silicon
+  add_project_arguments(
+    '-march=armv8.2-a+fp16+simd',
+    language : 'c'
+  )
+endif
+
+isyntax_includes = include_directories(
+  'src',
+  'src/isyntax',
+  'src/platform',
+  'src/third_party',
+  'src/utils',
+)
+
+isyntax_source = [
+  'src/isyntax/isyntax.c',
+  'src/isyntax/isyntax_reader.c',
+  'src/platform/platform.c',
+  'src/platform/work_queue.c',
+  'src/third_party/ltalloc.cc',
+  'src/third_party/yxml.c',
+  'src/utils/benaphore.c',
+  'src/utils/block_allocator.c',
+  'src/utils/timerutils.c',
+  'src/libisyntax.c',
+]
+
+if is_windows
+  isyntax_source += 'src/platform/win32_utils.c'
+else
+  isyntax_source += 'src/platform/linux_utils.c'
+endif
+
+isyntax = library(
+  'isyntax',
+  isyntax_source,
+  dependencies : [threads, winmm],
+  include_directories : isyntax_includes,
+  install : true,
+)
+libisyntax_dep = declare_dependency(
+  include_directories : include_directories('src'),
+  link_with : isyntax,
+)
+
+isyntax_example = executable(
+  'isyntax_example',
+  'src/examples/isyntax_example.c',
+  dependencies: [libisyntax_dep],
+)
+
+if tiff.found()
+  executable(
+    'isyntax-to-tiff',
+    'src/examples/isyntax_to_tiff.c',
+    dependencies : [libisyntax_dep, tiff, winmm, threads],
+    install : true,
+  )
+endif
+
+if get_option('tests')
+  python = import('python').find_installation(
+    modules: ['requests'],
+  )
+
+  # Thank you https://gitlab.com/BioimageInformaticsGroup/openphi
+  testslide = custom_target(
+    'testslide.isyntax',
+    command : [
+      python, files('test/fetch.py'),
+      'https://zenodo.org/record/5037046/files/testslide.isyntax?download=1',
+      '@OUTPUT@',
+    ],
+    console : true,
+    output : 'testslide.isyntax',
+  )
+
+  test('smoke_example_runs_no_args', isyntax_example)
+
+  # Test that we can show levels and that number of tiles shown is as
+  # expected for this test tile.
+  test(
+    'smoke_example_runs_with_test_slide_showing_levels',
+    python,
+    args : [
+      files('test/match.py'),
+      '-e', 'width.*=256',
+      '-e', 'height.*=384',
+      isyntax_example, testslide,
+    ],
+  )
+
+  # Regression test that the produced tile pixels did not change from expected.
+  test(
+    'regression_example_tile_3_5_10_pixel_check',
+    python,
+    args : [
+      files('test/compare-fixture.py'),
+      '-f', files('test/expected_output/testslide_example_tile_3_5_10.png'),
+      isyntax_example, testslide, '3', '5', '10',
+    ],
+  )
+
+  if not is_macos
+    # TODO: fix this test on macOS: fatal error: 'threads.h' file not found
+    thread_test = executable(
+      'thread_test',
+      'test/thread_test.c',
+      dependencies : [libisyntax_dep],
+      include_directories : [isyntax_includes],
+    )
+    test('smoke_thread_test', thread_test)
+  endif
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'tests',
+  type : 'boolean',
+  value : false,
+  description : 'Build tests'
+)

--- a/test/compare-fixture.py
+++ b/test/compare-fixture.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import tempfile
+
+parser = argparse.ArgumentParser(
+    'compare_fixture.py',
+    description='run program with arguments, compare output to fixture'
+)
+parser.add_argument(
+    '-f', '--fixture', type=argparse.FileType('rb'), required=True
+)
+parser.add_argument('command')
+parser.add_argument('arg', nargs='*')
+args = parser.parse_args()
+
+with tempfile.NamedTemporaryFile() as temp:
+    subprocess.run(
+        [args.command] + args.arg + [temp.name], check=True
+    )
+    output = temp.read()
+    if not output:
+        raise Exception('Program produced no output')
+    if output != args.fixture.read():
+        raise Exception('Output does not match fixture')

--- a/test/fetch.py
+++ b/test/fetch.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import pathlib
+import requests
+import shutil
+import sys
+
+url = sys.argv[1]
+file = pathlib.Path(sys.argv[2])
+
+if not file.exists():
+    print(f'Fetching {url}...')
+    resp = requests.get(url, stream=True)
+    resp.raise_for_status()
+    with file.open('wb') as fh:
+        shutil.copyfileobj(resp.raw, fh)

--- a/test/match.py
+++ b/test/match.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+
+parser = argparse.ArgumentParser(
+    'match.py',
+    description='run program with arguments, match stdout against regexes'
+)
+parser.add_argument('-e', '--regex', action='append')
+parser.add_argument('command')
+parser.add_argument('arg', nargs='*')
+args = parser.parse_args()
+if not args.regex:
+    raise Exception('No regex specified')
+
+result = subprocess.run(
+    [args.command] + args.arg, capture_output=True, text=True, check=True
+)
+for regex in args.regex:
+    if not re.search(regex, result.stdout):
+        raise Exception(f'Did not match: {regex}: {result.stdout}')


### PR DESCRIPTION
To integrate libisyntax into OpenSlide, a Meson-based build system must be available, either in the libisyntax repo or maintained separately downstream.  This is an initial port of the CMake build scripts to Meson, without any additional enhancements yet like version numbering, pkg-config support, or unbundled dependencies.  This also omits support for dynamically loading libtiff in `isyntax-to-tiff` on Windows, since it doesn't seem to add much.

How much interest is there in supporting Meson here?  The Meson code could be maintained alongside CMake, though doing that is admittedly somewhat painful, or in principle Meson could replace CMake entirely.  If you'd prefer to completely stick with CMake, the Meson port could live in [wrapdb](https://github.com/mesonbuild/wrapdb) instead for OpenSlide's purposes, though that would make Meson support unavailable to downstream package builders in Linux distros and elsewhere.