### PR TITLE
Add libisyntax_get_barcode()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ endif()
 add_library(isyntax ${LIBISYNTAX_COMMON_SOURCE_FILES})
 
 if (WIN32)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -static")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -static-libgcc -static")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS_DEBUG} -static-libgcc -static")
     target_link_libraries(isyntax winmm)
 else()
     find_package(Threads REQUIRED)
@@ -112,6 +115,9 @@ else()
     target_link_libraries(isyntax-to-tiff isyntax ${TIFF_LIBRARIES})
 endif()
 
+# Build example program: isyntax_dirwalk.c
+add_executable(isyntax-dirwalk src/examples/isyntax_dirwalk.c)
+target_link_libraries(isyntax-dirwalk isyntax)
 
 # TODO(avirodov): Consider moving testing to its own test/CMakeLists. This will require moving the library building
 #   to src/CMakeLists to avoid circular deps.

--- a/src/examples/isyntax_dirwalk.c
+++ b/src/examples/isyntax_dirwalk.c
@@ -1,0 +1,91 @@
+#include "libisyntax.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <malloc.h>
+
+
+#define CHECK_LIBISYNTAX_OK(_libisyntax_call) do { \
+    isyntax_error_t result = _libisyntax_call;     \
+    assert(result == LIBISYNTAX_OK);               \
+} while(0)
+
+
+#define LOG_VAR(fmt, var) printf("%s: %s=" fmt "\n", __FUNCTION__, #var, var)
+
+#ifdef _WIN32
+#define PATH_SEP "\\"
+#else
+#define PATH_SEP "/";
+#endif
+
+// This program loops through all the .isyntax files in a folder (including subfolders),
+// and outputs the barcode for each file to stdout (in comma-separated format).
+// This may be useful for large collections of WSIs where you can't tell which is which from the filename.
+
+// NOTE: the barcode/label information must be preserved for this to work.
+// This information might be deleted when using the Philips IMS export function (unless that setting is changed).
+
+int read_barcode_of_isyntax_files_in_directory(const char* dir, const char* subdir_prefix) {
+    // Looping through files in a folder.
+    // Reference: https://stackoverflow.com/questions/1271064/how-do-i-loop-through-all-files-in-a-folder-using-c
+    struct dirent *dp;
+	DIR *dfd;
+	if ((dfd = opendir(dir)) == NULL) {
+		fprintf(stderr, "Can't open %s\n", dir);
+		return 0;
+	}
+
+	char filename[260] ;
+	while ((dp = readdir(dfd)) != NULL) {
+		struct stat stbuf ;
+		sprintf(filename, "%s" PATH_SEP "%s", dir, dp->d_name);
+		if(stat(filename, &stbuf) == -1) {
+			printf("Unable to stat file: %s\n" , filename);
+			continue ;
+		}
+		if ((stbuf.st_mode & S_IFMT) == S_IFDIR) {
+			if (dp->d_name[0] != '.') {
+				char* subdir_path = malloc(260);
+				snprintf(subdir_path, 260, "%s" PATH_SEP "%s", dir, dp->d_name);
+				read_barcode_of_isyntax_files_in_directory(subdir_path, dp->d_name); // recurse into subdirectories
+				free(subdir_path);
+			}
+			continue; // Skip directories
+		} else {
+			size_t filename_len = strlen(dp->d_name);
+			const char* suffix = ".isyntax";
+			size_t suffix_len = strlen(suffix);
+			if (strncmp(dp->d_name + filename_len - suffix_len, suffix, suffix_len) == 0) {
+                // Open the iSyntax file in a special mode where the header is only read partially (for speed).
+				isyntax_t* isyntax;
+                if (libisyntax_open(filename, LIBISYNTAX_OPEN_FLAG_READ_BARCODE_ONLY, &isyntax) == LIBISYNTAX_OK) {
+                    // Print out the path of the .isyntax file + the barcode in .csv format.
+                    if (subdir_prefix) {
+						printf("%s" PATH_SEP "%s,%s\n", subdir_prefix, dp->d_name, libisyntax_get_barcode(isyntax));
+					} else {
+						printf("%s,%s\n", dp->d_name, libisyntax_get_barcode(isyntax));
+					}
+					libisyntax_close(isyntax);
+				}
+			}
+		}
+	}
+    return 0;
+}
+
+int main(int argc, char** argv) {
+	if (argc <= 1) {
+		printf("Usage: %s <directory_path> - output filename and barcode (comma-separated) for each iSyntax file in the directory and its subdirectories\n",
+		       argv[0], argv[0], argv[0], argv[0]);
+		return 0;
+	}
+
+	libisyntax_init();
+
+	char* dir = argv[1];
+	return read_barcode_of_isyntax_files_in_directory(dir, NULL);
+}

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -368,6 +368,7 @@ typedef struct isyntax_xml_parser_t {
 } isyntax_xml_parser_t;
 
 typedef struct isyntax_t {
+	enum libisyntax_open_flags_t open_flags;
 	i64 filesize;
 	file_handle_t file_handle;
 	isyntax_image_t images[16];
@@ -398,6 +399,7 @@ typedef struct isyntax_t {
 	float total_rgb_transform_time;
 	i32 data_model_major_version; // <100 (usually 5) for iSyntax format v1, >= 100 for iSyntax format v2
 	char barcode[64];
+	bool is_barcode_read;
 	work_queue_t* work_submission_queue;
 	volatile i32 refcount;
 } isyntax_t;
@@ -405,7 +407,7 @@ typedef struct isyntax_t {
 // function prototypes
 bool isyntax_hulsken_decompress(u8 *compressed, size_t compressed_size, i32 block_width, i32 block_height, i32 coefficient, i32 compressor_version, i16* out_buffer);
 void isyntax_set_work_queue(isyntax_t* isyntax, work_queue_t* work_queue);
-bool isyntax_open(isyntax_t* isyntax, const char* filename, bool init_allocators);
+bool isyntax_open(isyntax_t* isyntax, const char* filename, enum libisyntax_open_flags_t flags);
 void isyntax_destroy(isyntax_t* isyntax);
 void isyntax_idwt(icoeff_t* idwt, i32 quadrant_width, i32 quadrant_height, bool output_steps_as_png, const char* png_name);
 void isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 tile_x, i32 tile_y, block_allocator_t* ll_coeff_block_allocator,

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -220,13 +220,13 @@ isyntax_error_t libisyntax_init() {
     return LIBISYNTAX_OK;
 }
 
-isyntax_error_t libisyntax_open(const char* filename, int32_t is_init_allocators, isyntax_t** out_isyntax) {
+isyntax_error_t libisyntax_open(const char* filename, enum libisyntax_open_flags_t flags, isyntax_t** out_isyntax) {
     // Note(avirodov): intentionally not changing api of isyntax_open. We can do that later if needed and reduce
     // the size/count of wrappers.
     isyntax_t* result = malloc(sizeof(isyntax_t));
     memset(result, 0, sizeof(*result));
 
-    bool success = isyntax_open(result, filename, is_init_allocators);
+    bool success = isyntax_open(result, filename, flags);
     if (success) {
         *out_isyntax = result;
         return LIBISYNTAX_OK;

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -33,6 +33,14 @@ enum isyntax_pixel_format_t {
   _LIBISYNTAX_PIXEL_FORMAT_END,
 };
 
+enum libisyntax_open_flags_t {
+	// Set this flag to also initialize the allocators needed for tile loading.
+	LIBISYNTAX_OPEN_FLAG_INIT_ALLOCATORS = 1,
+
+	// Set this flag to only read the barcode, then abort (if you only need the barcode, this will be faster).
+	LIBISYNTAX_OPEN_FLAG_READ_BARCODE_ONLY = 2,
+};
+
 typedef struct isyntax_t isyntax_t;
 typedef struct isyntax_image_t isyntax_image_t;
 typedef struct isyntax_level_t isyntax_level_t;
@@ -41,7 +49,7 @@ typedef struct isyntax_cache_t isyntax_cache_t;
 //== Common API ==
 // TODO(avirodov): are repeated calls of libisyntax_init() allowed? Currently I believe not.
 isyntax_error_t libisyntax_init();
-isyntax_error_t libisyntax_open(const char* filename, int32_t is_init_allocators, isyntax_t** out_isyntax);
+isyntax_error_t libisyntax_open(const char* filename, enum libisyntax_open_flags_t flags, isyntax_t** out_isyntax);
 void            libisyntax_close(isyntax_t* isyntax);
 
 //== Getters API ==


### PR DESCRIPTION
This adds a way to retrieve the slide barcode. (Only works if the barcode information has not been deleted/blanked out.)

This also adds a new mode for opening .isyntax files where the header is only partially read (because if you only need the barcode information, opening the file in full could unneccesarily take a long time). Note that this changes the signature of libisyntax_open(), replacing is_init_allocators with an enum for flags (with the flag `LIBISYNTAX_OPEN_FLAG_INIT_ALLOCATORS=1` emulating the old behavior for compatiblity). Feedback is welcome.

An example program is added: see [isyntax_dirwalk.c.](https://github.com/amspath/libisyntax/blob/a54561fe172fb295a33fe450967fcf5e6dc131ae/src/examples/isyntax_dirwalk.c)

This program loops through all the .isyntax files in a folder (including subfolders) and outputs the barcode for each file to stdout (in comma-separated format). This may be useful for large collections of WSIs where you can't tell which is which from the filename.

NOTE: the barcode/label information must be preserved for this to work.
This information might be deleted when using the Philips IMS export function (unless that setting is changed).

