### PR TITLE
Add parsing and methods for metadata relevant for DICOM conversion

### DIFF
--- a/src/examples/isyntax_example.c
+++ b/src/examples/isyntax_example.c
@@ -16,14 +16,36 @@
 
 void print_isyntax_levels(isyntax_t* isyntax) {
     const isyntax_image_t* wsi_image = libisyntax_get_wsi_image(isyntax);
+    LOG_VAR("%s", libisyntax_get_acquisition_datetime(isyntax));
+    LOG_VAR("%s", libisyntax_get_manufacturer(isyntax));
+    LOG_VAR("%s", libisyntax_get_manufacturers_model_name(isyntax));
+    LOG_VAR("%s", libisyntax_get_derivation_description(isyntax));
+    LOG_VAR("%s", libisyntax_get_device_serial_number(isyntax));
+    for (int i = 0; i < libisyntax_get_software_versions_count(isyntax); ++i) {
+        LOG_VAR("%d", i);
+        LOG_VAR("%s", libisyntax_get_software_versions(isyntax, i));
+    }
+    for (int i = 0; i < libisyntax_get_date_of_last_calibration_count(isyntax); ++i) {
+        LOG_VAR("%d", i);
+        LOG_VAR("%s", libisyntax_get_date_of_last_calibration(isyntax, i));
+    }
+    for (int i = 0; i < libisyntax_get_time_of_last_calibration_count(isyntax); ++i) {
+        LOG_VAR("%d", i);
+        LOG_VAR("%s", libisyntax_get_time_of_last_calibration(isyntax, i));
+    }
 
+    LOG_VAR("%d", libisyntax_is_lossy_image_compression(isyntax));
+    LOG_VAR("%f", libisyntax_get_lossy_image_compression_ratio(isyntax));
+    LOG_VAR("%s", libisyntax_get_lossy_image_compression_method(isyntax));
     for (int i = 0; i < libisyntax_image_get_level_count(wsi_image); ++i) {
         const isyntax_level_t* level = libisyntax_image_get_level(wsi_image, i);
         LOG_VAR("%d", i);
         LOG_VAR("%d", libisyntax_level_get_scale(level));
         LOG_VAR("%d", libisyntax_level_get_width_in_tiles(level));
         LOG_VAR("%d", libisyntax_level_get_height_in_tiles(level));
+        LOG_VAR("%f", libisyntax_level_get_mpp_x(level));
     }
+    LOG_VAR("%s", libisyntax_scale_unit(isyntax));
 }
 
 int main(int argc, char** argv) {

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -356,9 +356,18 @@ static void isyntax_parse_ufsimport_child_node(isyntax_t* isyntax, u32 group, u3
 				default: {
 					console_print_verbose("Unknown element (0x%04x, 0x%04x)\n", group, element);
 				} break;
-				case 0x002A: /*DICOM_ACQUISITION_DATETIME*/     {} break; // "20210101103030.000000"
-				case 0x0070: /*DICOM_MANUFACTURER*/             {} break; // "PHILIPS"
-				case 0x1090: /*DICOM_MANUFACTURERS_MODEL_NAME*/ {} break; // "UFS Scanner"
+				case 0x002A: /*DICOM_ACQUISITION_DATETIME*/     {
+					strncpy(isyntax->dicom_acquisition_datetime, value, MIN(value_len, sizeof(isyntax->dicom_acquisition_datetime) - 1));
+					isyntax->dicom_acquisition_datetime[MIN(value_len, sizeof(isyntax->dicom_acquisition_datetime) - 1)] = '\0';
+				} break; // "20210101103030.000000"
+				case 0x0070: /*DICOM_MANUFACTURER*/             {
+					strncpy(isyntax->dicom_manufacturer, value, MIN(value_len, sizeof(isyntax->dicom_manufacturer) - 1));
+					isyntax->dicom_manufacturer[MIN(value_len, sizeof(isyntax->dicom_manufacturer) - 1)] = '\0';
+				} break; // "PHILIPS"
+				case 0x1090: /*DICOM_MANUFACTURERS_MODEL_NAME*/ {
+					strncpy(isyntax->dicom_manufacturers_model_name, value, MIN(value_len, sizeof(isyntax->dicom_manufacturers_model_name) - 1));
+					isyntax->dicom_manufacturers_model_name[MIN(value_len, sizeof(isyntax->dicom_manufacturers_model_name) - 1)] = '\0';
+				} break; // "UFS Scanner"
 			}
 		}; break;
 		case 0x0018: {
@@ -366,10 +375,86 @@ static void isyntax_parse_ufsimport_child_node(isyntax_t* isyntax, u32 group, u3
 				default: {
 					console_print_verbose("Unknown element (0x%04x, 0x%04x)\n", group, element);
 				} break;
-				case 0x1000: /*DICOM_DEVICE_SERIAL_NUMBER*/     {} break; // "FMT<4-digit number>"
-				case 0x1020: /*DICOM_SOFTWARE_VERSIONS*/        {} break; // "<versionnumber>" "<versionnumber>"
-				case 0x1200: /*DICOM_DATE_OF_LAST_CALIBRATION*/ {} break; // "20210101"
-				case 0x1201: /*DICOM_TIME_OF_LAST_CALIBRATION*/ {} break; // "100730"
+				case 0x1000: /*DICOM_DEVICE_SERIAL_NUMBER*/     {
+					strncpy(isyntax->dicom_device_serial_number, value, MIN(value_len, sizeof(isyntax->dicom_device_serial_number) - 1));
+					isyntax->dicom_device_serial_number[MIN(value_len, sizeof(isyntax->dicom_device_serial_number) - 1)] = '\0';
+				} break; // "FMT<4-digit number>"
+				case 0x1020: /*DICOM_SOFTWARE_VERSIONS*/        {
+					if (value_len < 2) {
+						// Each version is wrapped in quotes, so at least 2 characters are needed.
+						isyntax->dicom_software_versions = NULL;
+						isyntax->dicom_software_versions_count = 0;
+						break;
+					}
+					// Count number of versions by counting number of '" "'
+					i32 version_count = 1;
+					for (i32 i = 0; i + 2 < value_len; ++i) {
+						if (value[i] == '"' && value[i + 1] == ' ' && value[i + 2] == '"') {
+							version_count++;
+						}
+					}
+					isyntax->dicom_software_versions = malloc(version_count * sizeof(*isyntax->dicom_software_versions));
+					if (!isyntax->dicom_software_versions) {
+						isyntax->dicom_software_versions_count = 0;
+						break;
+					}
+					i32 version_index = 0;
+					const char* version_start = value + 1;
+					for (i32 i = 0; i < value_len; ++i) {
+						if (version_index >= version_count) {
+							break; // no more versions to parse
+						}
+						// Check if either '" "' or '"' at end of string
+						if (value[i] == '"' && ((i + 2 < value_len && value[i + 1] == ' ' && value[i + 2] == '"') || i + 1 == value_len)) {
+							size_t version_len = value + i - version_start;
+							strncpy(isyntax->dicom_software_versions[version_index], version_start, MIN(version_len, sizeof(isyntax->dicom_software_versions[version_index]) - 1));
+							isyntax->dicom_software_versions[version_index][MIN(version_len, sizeof(isyntax->dicom_software_versions[version_index]) - 1)] = '\0';
+							version_index++;
+							version_start = value + i + 3;
+						}
+					}
+					isyntax->dicom_software_versions_count = version_count;
+
+				} break; // "<versionnumber>" "<versionnumber>"
+				case 0x1200: /*DICOM_DATE_OF_LAST_CALIBRATION*/ {
+					if (value_len < 10) {
+						isyntax->dicom_date_of_last_calibration = NULL;
+						isyntax->dicom_date_of_last_calibration_count = 0;
+						break;
+					}
+					i32 number_of_values = 1 + (value_len - 10) / 11;
+					isyntax->dicom_date_of_last_calibration = malloc(number_of_values * sizeof(*isyntax->dicom_date_of_last_calibration));
+					if (!isyntax->dicom_date_of_last_calibration) {
+						isyntax->dicom_date_of_last_calibration_count = 0;
+						break;
+					};
+					for (i32 i = 0; i < number_of_values; ++i) {
+						strncpy(isyntax->dicom_date_of_last_calibration[i], value + 1 + i * 11, MIN(8, sizeof(isyntax->dicom_date_of_last_calibration[i]) - 1));
+						isyntax->dicom_date_of_last_calibration[i][MIN(8, sizeof(isyntax->dicom_date_of_last_calibration[i]) - 1)] = '\0';
+					}
+					isyntax->dicom_date_of_last_calibration_count = number_of_values;
+
+
+				} break; // "20210101"
+				case 0x1201: /*DICOM_TIME_OF_LAST_CALIBRATION*/ {
+					if (value_len < 8) {
+						isyntax->dicom_time_of_last_calibration = NULL;
+						isyntax->dicom_time_of_last_calibration_count = 0;
+						break;
+					}
+					i32 number_of_values = 1 + (value_len - 8) / 9;
+					isyntax->dicom_time_of_last_calibration = malloc(number_of_values * sizeof(*isyntax->dicom_time_of_last_calibration));
+					if (!isyntax->dicom_time_of_last_calibration) {
+						isyntax->dicom_time_of_last_calibration_count = 0;
+						break;
+					};
+					for (i32 i = 0; i < number_of_values; ++i) {
+						strncpy(isyntax->dicom_time_of_last_calibration[i], value + 1 + i * 9, MIN(6, sizeof(isyntax->dicom_time_of_last_calibration[i]) - 1));
+						isyntax->dicom_time_of_last_calibration[i][MIN(6, sizeof(isyntax->dicom_time_of_last_calibration[i]) - 1)] = '\0';
+					}
+					isyntax->dicom_time_of_last_calibration_count = number_of_values;
+
+				} break; // "100730"
 			}
 		} break;
 		case 0x101D: {
@@ -434,7 +519,8 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 					console_print_verbose("Unknown element (0x%04x, 0x%04x)\n", group, element);
 				} break;
 				case 0x2111: /*DICOM_DERIVATION_DESCRIPTION*/   {         // "PHILIPS UFS V%s | Quality=%d | DWT=%d | Compressor=%d"
-
+					strncpy(isyntax->dicom_derivation_description, value, MIN(value_len, sizeof(isyntax->dicom_derivation_description) - 1));
+					isyntax->dicom_derivation_description[MIN(value_len, sizeof(isyntax->dicom_derivation_description) - 1)] = '\0';
 				} break;
 			}
 		}; break;
@@ -458,9 +544,27 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 					image->base64_encoded_icc_profile_file_offset = isyntax->parser.content_file_offset;
 					image->base64_encoded_icc_profile_len = value_len;
 				} break;
-				case 0x2110: /*DICOM_LOSSY_IMAGE_COMPRESSION*/          {} break;
-				case 0x2112: /*DICOM_LOSSY_IMAGE_COMPRESSION_RATIO*/    {} break;
-				case 0x2114: /*DICOM_LOSSY_IMAGE_COMPRESSION_METHOD*/   {} break; // "PHILIPS_DP_1_0"
+				case 0x2110: /*DICOM_LOSSY_IMAGE_COMPRESSION*/          {
+					isyntax->dicom_lossy_image_compression = (strcmp(value, "01") == 0);
+				} break;
+				case 0x2112: /*DICOM_LOSSY_IMAGE_COMPRESSION_RATIO*/    {
+					// Assumes only one value is present.
+					isyntax->dicom_lossy_image_compression_ratio = atof(value);
+				} break;
+				case 0x2114: /*DICOM_LOSSY_IMAGE_COMPRESSION_METHOD*/   {
+					// Assumes only one value is present.
+					// Strip starting and ending " if present
+					size_t start = 0, end = value_len;
+					if (value_len > 0 && value[0] == '"') {
+						start = 1;
+					}
+					if (end > start && value[end - 1] == '"') {
+						end--;
+					}
+					size_t copy_len = MIN(end - start, sizeof(isyntax->dicom_lossy_image_compression_method) - 1);
+					strncpy(isyntax->dicom_lossy_image_compression_method, value + start, copy_len);
+					isyntax->dicom_lossy_image_compression_method[copy_len] = '\0';
+				} break; // "PHILIPS_DP_1_0"
 			}
 		} break;
 		case 0x301D: {
@@ -513,7 +617,9 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 				case 0x2003: /*UFS_IMAGE_DIMENSIONS*/                       {} break;
 				case 0x2004: /*UFS_IMAGE_DIMENSION_NAME*/                   {} break;
 				case 0x2005: /*UFS_IMAGE_DIMENSION_TYPE*/                   {} break;
-				case 0x2006: /*UFS_IMAGE_DIMENSION_UNIT*/                   {} break;
+				case 0x2006: /*UFS_IMAGE_DIMENSION_UNIT*/                   {
+					strncpy(isyntax->image_dimension_unit, value, MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1));
+					isyntax->image_dimension_unit[MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1)] = '\0';				} break;
 				case 0x2007: /*UFS_IMAGE_DIMENSION_SCALE_FACTOR*/           {
 					float mpp = atof(value);
 					if (isyntax->parser.dimension_index == 0 /*x*/) {
@@ -3513,6 +3619,18 @@ void isyntax_destroy(isyntax_t* isyntax) {
 	if (isyntax->white_dummy_coeff) {
 		free(isyntax->white_dummy_coeff);
 		isyntax->white_dummy_coeff = NULL;
+	}
+	if (isyntax->dicom_software_versions) {
+		free(isyntax->dicom_software_versions);
+		isyntax->dicom_software_versions = NULL;
+	}
+	if (isyntax->dicom_date_of_last_calibration) {
+		free(isyntax->dicom_date_of_last_calibration);
+		isyntax->dicom_date_of_last_calibration = NULL;
+	}
+	if (isyntax->dicom_time_of_last_calibration) {
+		free(isyntax->dicom_time_of_last_calibration);
+		isyntax->dicom_time_of_last_calibration = NULL;
 	}
 	for (i32 image_index = 0; image_index < isyntax->image_count; ++image_index) {
 		isyntax_image_t* image = isyntax->images + image_index;

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -403,6 +403,21 @@ typedef struct isyntax_t {
 	isyntax_cache_t* cache;
 	work_queue_t* work_submission_queue;
 	volatile i32 refcount;
+	char dicom_acquisition_datetime[33]; // e.g. "20210609111602.000000"
+	char dicom_manufacturer[65]; // e.g. "PHILIPS"
+	char dicom_manufacturers_model_name[65]; // e.g. "UFS Scanner"
+	char dicom_device_serial_number[65]; // e.g. "FMT0586"
+	char (*dicom_software_versions)[65]; // e.g. ""1.8.6824" "20180906_R51""
+	i32 dicom_software_versions_count;
+	char dicom_derivation_description[1025]; // e.g. PHILIPS UFS V1.8.6824 | Quality=2 | DWT=1 | Compressor=16
+	char (*dicom_date_of_last_calibration)[9];
+	i32 dicom_date_of_last_calibration_count;
+	char (*dicom_time_of_last_calibration)[7];
+	i32 dicom_time_of_last_calibration_count;
+	bool dicom_lossy_image_compression;
+	double dicom_lossy_image_compression_ratio;
+	char dicom_lossy_image_compression_method[65]; // e.g. "PHILIPS_DP_1_0"
+	char image_dimension_unit[65];
 } isyntax_t;
 
 // function prototypes

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -289,6 +289,74 @@ const char* libisyntax_get_barcode(const isyntax_t* isyntax) {
 	return isyntax->barcode;
 }
 
+const char* libisyntax_get_acquisition_datetime(const isyntax_t* isyntax) {
+	return isyntax->dicom_acquisition_datetime;
+}
+
+const char* libisyntax_get_manufacturer(const isyntax_t* isyntax) {
+	return isyntax->dicom_manufacturer;
+}
+
+const char* libisyntax_get_manufacturers_model_name(const isyntax_t* isyntax) {
+    return isyntax->dicom_manufacturers_model_name;
+}
+
+const char* libisyntax_scale_unit(const isyntax_t* isyntax) {
+    return isyntax->image_dimension_unit;
+}
+const char* libisyntax_get_derivation_description(const isyntax_t* isyntax) {
+    return isyntax->dicom_derivation_description;
+}
+
+const char* libisyntax_get_device_serial_number(const isyntax_t* isyntax) {
+    return isyntax->dicom_device_serial_number;
+}
+
+const int32_t libisyntax_get_software_versions_count(const isyntax_t* isyntax) {
+    return isyntax->dicom_software_versions_count;
+}
+
+const char* libisyntax_get_software_versions(const isyntax_t* isyntax, int32_t index) {
+    if (index < 0 || index >= isyntax->dicom_software_versions_count) {
+        return NULL;
+    }
+    return isyntax->dicom_software_versions[index];
+}
+
+const int32_t libisyntax_get_date_of_last_calibration_count(const isyntax_t* isyntax) {
+    return isyntax->dicom_date_of_last_calibration_count;
+}
+
+const char* libisyntax_get_date_of_last_calibration(const isyntax_t* isyntax, int32_t index) {
+    if (index < 0 || index >= isyntax->dicom_date_of_last_calibration_count) {
+        return NULL;
+    }
+    return isyntax->dicom_date_of_last_calibration[index];
+}
+
+const int32_t libisyntax_get_time_of_last_calibration_count(const isyntax_t* isyntax) {
+    return isyntax->dicom_time_of_last_calibration_count;
+}
+
+const char* libisyntax_get_time_of_last_calibration(const isyntax_t* isyntax, int32_t index) {
+    if (index < 0 || index >= isyntax->dicom_time_of_last_calibration_count) {
+        return NULL;
+    }
+    return isyntax->dicom_time_of_last_calibration[index];
+}
+
+bool libisyntax_is_lossy_image_compression(const isyntax_t* isyntax) {
+    return isyntax->dicom_lossy_image_compression;
+}
+
+double libisyntax_get_lossy_image_compression_ratio(const isyntax_t* isyntax) {
+    return isyntax->dicom_lossy_image_compression_ratio;
+}
+
+const char* libisyntax_get_lossy_image_compression_method(const isyntax_t* isyntax) {
+    return isyntax->dicom_lossy_image_compression_method;
+}
+
 int32_t libisyntax_image_get_level_count(const isyntax_image_t* image) {
     return image->level_count;
 }

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // API conventions:
 // - return type is one of:
@@ -59,6 +60,22 @@ const isyntax_image_t* libisyntax_get_wsi_image(const isyntax_t* isyntax);
 const isyntax_image_t* libisyntax_get_label_image(const isyntax_t* isyntax);
 const isyntax_image_t* libisyntax_get_macro_image(const isyntax_t* isyntax);
 const char*            libisyntax_get_barcode(const isyntax_t* isyntax);
+const char*            libisyntax_get_acquisition_datetime(const isyntax_t* isyntax);
+const char*            libisyntax_get_manufacturer(const isyntax_t* isyntax);
+const char*            libisyntax_get_manufacturers_model_name(const isyntax_t* isyntax);
+const char*            libisyntax_get_derivation_description(const isyntax_t* isyntax);
+const char*            libisyntax_get_device_serial_number(const isyntax_t* isyntax);
+int32_t                libisyntax_get_software_versions_count(const isyntax_t* isyntax);
+const char*            libisyntax_get_software_versions(const isyntax_t* isyntax, int32_t index);
+int32_t                libisyntax_get_date_of_last_calibration_count(const isyntax_t* isyntax);
+const char*            libisyntax_get_date_of_last_calibration(const isyntax_t* isyntax, int32_t index);
+int32_t                libisyntax_get_time_of_last_calibration_count(const isyntax_t* isyntax);
+const char*            libisyntax_get_time_of_last_calibration(const isyntax_t* isyntax, int32_t index);
+const bool             libisyntax_is_lossy_image_compression(const isyntax_t* isyntax);
+const double           libisyntax_get_lossy_image_compression_ratio(const isyntax_t* isyntax);
+const char*            libisyntax_get_lossy_image_compression_method(const isyntax_t* isyntax);
+const char*            libisyntax_scale_unit(const isyntax_t* isyntax);
+
 int32_t                libisyntax_image_get_level_count(const isyntax_image_t* image);
 int32_t                libisyntax_image_get_offset_x(const isyntax_image_t* image);
 int32_t                libisyntax_image_get_offset_y(const isyntax_image_t* image);


### PR DESCRIPTION
- Allocated string lengths are based on the [`Length of Value` for the VR](https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_6.2.html) that the corresponding DICOM attribute should have.
- `DICOM_SOFTWARE_VERSIONS`, `DICOM_DATE_OF_LAST_CALIBRATION`, and `DICOM_TIME_OF_LAST_CALIBRATION` are specified as `IStringArray` in the isyntax specifications, and could potentially contain multiple items.
- Although the corresponding DICOM attributes for `DICOM_LOSSY_IMAGE_COMPRESSION_RATIO` and `DICOM_LOSSY_IMAGE_COMPRESSION_METHOD` allow multiple values, the isyntax specification specifies them as IDouble and IString, so parse them as single values.

C is not my strongest language, so please review thoroughly and give feedback :)