### PR TITLE
Only collect the mpp if current image type is WSI

### DIFF
--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -621,13 +621,15 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 					strncpy(isyntax->image_dimension_unit, value, MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1));
 					isyntax->image_dimension_unit[MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1)] = '\0';				} break;
 				case 0x2007: /*UFS_IMAGE_DIMENSION_SCALE_FACTOR*/           {
-					float mpp = atof(value);
-					if (isyntax->parser.dimension_index == 0 /*x*/) {
-						isyntax->mpp_x = mpp;
-						isyntax->is_mpp_known = true;
-					} else if (isyntax->parser.dimension_index == 1 /*y*/) {
-						isyntax->mpp_y = mpp;
-						isyntax->is_mpp_known = true;
+					if (isyntax->parser.current_image_type == ISYNTAX_IMAGE_TYPE_WSI) {
+						float mpp = atof(value);
+						if (isyntax->parser.dimension_index == 0 /*x*/) {
+							isyntax->mpp_x = mpp;
+							isyntax->is_mpp_known = true;
+						} else if (isyntax->parser.dimension_index == 1 /*y*/) {
+							isyntax->mpp_y = mpp;
+							isyntax->is_mpp_known = true;
+						}
 					}
 				} break;
 				case 0x2008: /*UFS_IMAGE_DIMENSION_DISCRETE_VALUES_STRING*/ {} break;


### PR DESCRIPTION
Encountered some WSIs that have scale-factor set for macro/label images in the isyntax file. I've reproduced this issue with a synthetic isyntax file: [mpp-bug.isyntax.zip](https://github.com/user-attachments/files/27163030/mpp-bug.isyntax.zip).

Running the `isyntax_example` tool against this file:

```sh
$ builddir/isyntax_example mpp-bug.isyntax | grep mpp_x
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=27.170118
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=54.340237
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=108.680473
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=217.360947
```

With this patch:

```sh
$ builddir/isyntax_example mpp-bug.isyntax | grep mpp_x
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=0.250000
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=0.500000
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=1.000000
print_isyntax_levels: libisyntax_level_get_mpp_x(level)=2.000000
```