### PR TITLE
Fix build on aarch64-linux and install headers 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project(
   'libisyntax', 'c', 'cpp',
+  version: '0.1.0',
   license : 'BSD-2-Clause',
   meson_version : '>=0.51.0',
   default_options : [
@@ -78,6 +79,10 @@ libisyntax_dep = declare_dependency(
   include_directories : include_directories('src'),
   link_with : isyntax,
 )
+
+pkg = import('pkgconfig')
+pkg.generate(isyntax)
+install_headers('src/libisyntax.h')
 
 isyntax_example = executable(
   'isyntax_example',

--- a/src/platform/intrinsics.h
+++ b/src/platform/intrinsics.h
@@ -36,7 +36,7 @@
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
 /* GCC-compatible compiler, targeting x86/x86-64 */
 #include <x86intrin.h>
-#elif defined(__GNUC__) && defined(__ARM_NEON__)
+#elif defined(__GNUC__) && (defined(__ARM_NEON__) || defined(__ARM_NEON))
 /* GCC-compatible compiler, targeting ARM with NEON */
      #include <arm_neon.h>
 #elif defined(__GNUC__) && defined(__IWMMXT__)
@@ -144,7 +144,7 @@ static inline u32 atomic_or(volatile u32* x, u32 mask) {
 }
 
 static inline u32 bit_scan_forward(u32 x) {
-	return _bit_scan_forward(x);
+	return __builtin_ctz(x);
 }
 
 #endif
@@ -257,6 +257,6 @@ static inline i32 popcount(u32 x) {
 }
 #else
 static inline i32 popcount(u32 x) {
-    return _popcnt32(x);
+    return __builtin_popcount(x);
 }
 #endif

--- a/src/third_party/ltalloc.cc
+++ b/src/third_party/ltalloc.cc
@@ -210,7 +210,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #		define PAUSE __asm__ __volatile__("rd    %%ccr, %%g0\n\t" ::: "memory")
 #	elif defined(__ppc__)  || defined(_ARCH_PPC) || defined(_ARCH_PWR) || defined(_ARCH_PWR2) || defined(_POWER)
 #		define PAUSE __asm__ __volatile__("or 27,27,27")
-#	elif defined(__ANDROID__) || defined(__arm64)
+#	elif defined(__ANDROID__) || defined(__arm64) || defined(__aarch64__)
 #		include <sched.h> //for sched_yield
 #		define PAUSE sched_yield()
 #	else


### PR DESCRIPTION
The project is failing to build on aarch64-linux targets. In short:

- Check for `defined(__ARM_NEON)` for compilers that define `__ARM_NEON` and not `__ARM_NEON__`.
- In `bit_scan_forward`, replace `_bit_scan_forward` with [`__builtin_ctz`](https://gcc.gnu.org/onlinedocs/gcc/Bit-Operation-Builtins.html).
- In `popcount`, replace `_popcnt32` with [`__builtin_popcount`](https://gcc.gnu.org/onlinedocs/gcc/Bit-Operation-Builtins.html).
- In `ltalloc.cc` check for `defined(__aarch64__)`.

Also included in the `meson.build` installation of header file and pc entry. This is useful for linking the shared object and using it in downstream codebases without vendoring in this project. 

