### PR TITLE
Add libisyntax_get_data_model_major_version

### DIFF
--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -476,7 +476,8 @@ static void isyntax_parse_ufsimport_child_node(isyntax_t* isyntax, u32 group, u3
 				} break;
 				case 0x1001: /*PIM_DP_UFS_INTERFACE_VERSION*/          {
 					// Value will likely be "5.0" for v1 iSyntax files, "100.5" for v2 iSyntax files
-					isyntax->data_model_major_version = atoi(value);
+					if (sscanf(value, "%" SCNd32 ".%" SCNd32, &isyntax->data_model_major_version, &isyntax->data_model_minor_version) != 2)
+						isyntax->data_model_minor_version = 0;
 				} break;
 				case 0x1002: /*PIM_DP_UFS_BARCODE*/ {
 					// "<base64-encoded barcode value>"
@@ -3675,5 +3676,3 @@ void isyntax_destroy(isyntax_t* isyntax) {
 	}
 	file_handle_close(isyntax->file_handle);
 }
-
-

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -398,6 +398,7 @@ typedef struct isyntax_t {
 	float loading_time;
 	float total_rgb_transform_time;
 	i32 data_model_major_version; // <100 (usually 5) for iSyntax format v1, >= 100 for iSyntax format v2
+	i32 data_model_minor_version;
 	char barcode[64];
 	bool is_barcode_read;
 	isyntax_cache_t* cache;

--- a/src/libisyntax.c
+++ b/src/libisyntax.c
@@ -369,6 +369,14 @@ const char* libisyntax_get_lossy_image_compression_method(const isyntax_t* isynt
     return isyntax->dicom_lossy_image_compression_method;
 }
 
+int32_t libisyntax_get_data_model_major_version(const isyntax_t* isyntax) {
+	return isyntax->data_model_major_version;
+}
+
+int32_t libisyntax_get_data_model_minor_version(const isyntax_t* isyntax) {
+	return isyntax->data_model_minor_version;
+}
+
 int32_t libisyntax_image_get_level_count(const isyntax_image_t* image) {
     return image->level_count;
 }

--- a/src/libisyntax.h
+++ b/src/libisyntax.h
@@ -78,6 +78,8 @@ const char*            libisyntax_get_time_of_last_calibration(const isyntax_t* 
 bool                   libisyntax_is_lossy_image_compression(const isyntax_t* isyntax);
 double                 libisyntax_get_lossy_image_compression_ratio(const isyntax_t* isyntax);
 const char*            libisyntax_get_lossy_image_compression_method(const isyntax_t* isyntax);
+int32_t                libisyntax_get_data_model_major_version(const isyntax_t* isyntax);
+int32_t                libisyntax_get_data_model_minor_version(const isyntax_t* isyntax);
 const char*            libisyntax_scale_unit(const isyntax_t* isyntax);
 
 int32_t                libisyntax_image_get_level_count(const isyntax_image_t* image);

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -128,6 +128,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+#include <inttypes.h>
 
 #if COMPILER_MSVC
 #include <io.h>


### PR DESCRIPTION
This value is useful for identifying the isyntax file format version. Use case for exposing this value in the API would be to validate and reject invalid/unexpected formats when reading the image.