### PR TITLE
update isyntax_source in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,11 +52,11 @@ isyntax_includes = include_directories(
 isyntax_source = [
   'src/isyntax/isyntax.c',
   'src/isyntax/isyntax_reader.c',
+  'src/platform/platform_mutex.c',
   'src/platform/platform.c',
   'src/platform/work_queue.c',
   'src/third_party/ltalloc.cc',
   'src/third_party/yxml.c',
-  'src/utils/benaphore.c',
   'src/utils/block_allocator.c',
   'src/utils/timerutils.c',
   'src/libisyntax.c',


### PR DESCRIPTION
Another build fix. I must have had unclean build directory when compiling previously. 

- `src/utils/benaphore.c` is gone, removed (90f0fac9).
- `src/platform/platform_mutex.c` added (90f0fac9).